### PR TITLE
Add support for custom_updater and the tracker card

### DIFF
--- a/aarlo/__init__.py
+++ b/aarlo/__init__.py
@@ -16,6 +16,8 @@ from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.const import (
         CONF_USERNAME, CONF_PASSWORD, CONF_SCAN_INTERVAL)
 
+__version__ = '0.0.1'
+
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ATTRIBUTION = "Data provided by arlo.netgear.com"

--- a/aarlo/__init__.py
+++ b/aarlo/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.const import (
         CONF_USERNAME, CONF_PASSWORD, CONF_SCAN_INTERVAL)
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/aarlo/pyaarlo/__init__.py
+++ b/aarlo/pyaarlo/__init__.py
@@ -25,6 +25,8 @@ from custom_components.aarlo.pyaarlo.constant import ( BLANK_IMAGE,
 
 _LOGGER = logging.getLogger('pyaarlo')
 
+__version__ = '0.0.2'
+
 class PyArlo(object):
 
     def __init__( self,username,password,name='aarlo',

--- a/changelog
+++ b/changelog
@@ -1,0 +1,1 @@
+0.0.1: Initial version

--- a/custom_cards.json
+++ b/custom_cards.json
@@ -1,8 +1,8 @@
 {
     "aarlo-glance": {
-      "version": "0.0.2",
-      "remote_location": "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/www/aarlo-glance.js",
-      "visit_repo": "https://github.com/rccoleman/hass-aarlo",
-      "changelog": "https://github.com/rccoleman/hass-aarlo/blob/master/changelog"
+        "changelog": "https://github.com/rccoleman/hass-aarlo/blob/master/changelog",
+        "remote_location": "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/www/aarlo-glance.js",
+        "version": "0.0.2",
+        "visit_repo": "https://github.com/rccoleman/hass-aarlo"
     }
 }

--- a/custom_cards.json
+++ b/custom_cards.json
@@ -2,7 +2,7 @@
     "aarlo-glance": {
         "changelog": "https://github.com/rccoleman/hass-aarlo/blob/master/changelog",
         "remote_location": "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/www/aarlo-glance.js",
-        "version": "0.0.2",
+        "version": "0.0.3",
         "visit_repo": "https://github.com/rccoleman/hass-aarlo"
     }
 }

--- a/custom_cards.json
+++ b/custom_cards.json
@@ -1,0 +1,8 @@
+{
+    "aarlo-glance": {
+      "version": "0.0.2",
+      "remote_location": "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/www/aarlo-glance.js",
+      "visit_repo": "https://github.com/rccoleman/hass-aarlo",
+      "changelog": "https://github.com/rccoleman/hass-aarlo/blob/master/changelog",
+    }
+}

--- a/custom_cards.json
+++ b/custom_cards.json
@@ -3,6 +3,6 @@
       "version": "0.0.2",
       "remote_location": "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/www/aarlo-glance.js",
       "visit_repo": "https://github.com/rccoleman/hass-aarlo",
-      "changelog": "https://github.com/rccoleman/hass-aarlo/blob/master/changelog",
+      "changelog": "https://github.com/rccoleman/hass-aarlo/blob/master/changelog"
     }
 }

--- a/custom_components.json
+++ b/custom_components.json
@@ -1,6 +1,6 @@
 {
     "aarlo_component": {
-        "version": "0.0.1",
+        "version": "0.0.2",
         "local_location": "/custom_components/aarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/__init__.py",
         "visit_repo": "https://github.com/rccoleman/hass-aarlo",
@@ -25,7 +25,7 @@
         ]
     },
     "aarlo_www": {
-        "version": "0.0.1",
+        "version": "0.0.2",
         "local_location": "/www/aarlo-glance.js",
         "remote_location": "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/www/aarlo-glance.js",
         "visit_repo": "https://github.com/rccoleman/hass-aarlo",

--- a/custom_components.json
+++ b/custom_components.json
@@ -24,10 +24,10 @@
              "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/device.py"
         ]
     },
-    "pyarlo": {
+    "pyaarlo": {
         "version": "0.0.2",
         "local_location": "/custom_components/aarlo/pyaarlo/__init__.py",
-        "remote_location": "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyarlo/__init__.py",
+        "remote_location": "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/__init__.py",
         "visit_repo": "https://github.com/rccoleman/hass-aarlo",
         "changelog": "https://github.com/rccoleman/hass-aarlo/blob/master/changelog",
         "resources": [

--- a/custom_components.json
+++ b/custom_components.json
@@ -1,0 +1,34 @@
+{
+    "aarlo_component": {
+        "version": "0.0.1",
+        "local_location": "/custom_components/aarlo/__init__.py",
+        "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/__init__.py",
+        "visit_repo": "https://github.com/twrecked/hass-aarlo",
+        "changelog": "https://github.com/twrecked/hass-aarlo/add_me",
+        "resources": [
+             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/binary_sensor.py",
+             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/sensor.py",
+             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/alarm_control_panel.py",
+             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/camera.py",
+             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/backend.py",
+             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/storage.py",
+             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/__init__.py",
+             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/media.py",
+             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/util.py",
+             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/camera.py",
+             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/background.py",
+             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/sseclient.py",
+             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/doorbell.py",
+             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/base.py",
+             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/constant.py",
+             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/device.py"
+        ]
+    },
+    "aarlo_www": {
+        "version": "0.0.1",
+        "local_location": "/www/aarlo-glance.js",
+        "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/www/aarlo-glance.js",
+        "visit_repo": "https://github.com/twrecked/hass-aarlo",
+        "changelog": "https://github.com/twrecked/hass-aarlo/add_me"
+    }
+}

--- a/custom_components.json
+++ b/custom_components.json
@@ -4,7 +4,7 @@
         "local_location": "/custom_components/aarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/__init__.py",
         "visit_repo": "https://github.com/twrecked/hass-aarlo",
-        "changelog": "https://github.com/twrecked/hass-aarlo/add_me",
+        "changelog": "https://github.com/rccoleman/hass-aarlo/blob/master/changelog",
         "resources": [
              "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/binary_sensor.py",
              "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/sensor.py",
@@ -29,6 +29,6 @@
         "local_location": "/www/aarlo-glance.js",
         "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/www/aarlo-glance.js",
         "visit_repo": "https://github.com/twrecked/hass-aarlo",
-        "changelog": "https://github.com/twrecked/hass-aarlo/add_me"
+        "changelog": "https://github.com/rccoleman/hass-aarlo/blob/master/changelog"
     }
 }

--- a/custom_components.json
+++ b/custom_components.json
@@ -1,5 +1,5 @@
 {
-    "aarlo_component": {
+    "aarlo": {
         "version": "0.0.2",
         "local_location": "/custom_components/aarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/__init__.py",

--- a/custom_components.json
+++ b/custom_components.json
@@ -2,33 +2,33 @@
     "aarlo_component": {
         "version": "0.0.1",
         "local_location": "/custom_components/aarlo/__init__.py",
-        "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/__init__.py",
-        "visit_repo": "https://github.com/twrecked/hass-aarlo",
+        "remote_location": "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/__init__.py",
+        "visit_repo": "https://github.com/rccoleman/hass-aarlo",
         "changelog": "https://github.com/rccoleman/hass-aarlo/blob/master/changelog",
         "resources": [
-             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/binary_sensor.py",
-             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/sensor.py",
-             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/alarm_control_panel.py",
-             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/camera.py",
-             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/backend.py",
-             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/storage.py",
-             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/__init__.py",
-             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/media.py",
-             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/util.py",
-             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/camera.py",
-             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/background.py",
-             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/sseclient.py",
-             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/doorbell.py",
-             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/base.py",
-             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/constant.py",
-             "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/device.py"
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/binary_sensor.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/sensor.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/alarm_control_panel.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/camera.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/backend.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/storage.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/__init__.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/media.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/util.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/camera.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/background.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/sseclient.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/doorbell.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/base.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/constant.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/device.py"
         ]
     },
     "aarlo_www": {
         "version": "0.0.1",
         "local_location": "/www/aarlo-glance.js",
-        "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/www/aarlo-glance.js",
-        "visit_repo": "https://github.com/twrecked/hass-aarlo",
+        "remote_location": "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/www/aarlo-glance.js",
+        "visit_repo": "https://github.com/rccoleman/hass-aarlo",
         "changelog": "https://github.com/rccoleman/hass-aarlo/blob/master/changelog"
     }
 }

--- a/custom_components.json
+++ b/custom_components.json
@@ -24,11 +24,25 @@
              "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/device.py"
         ]
     },
-    "aarlo_www": {
+    "pyarlo": {
         "version": "0.0.2",
-        "local_location": "/www/aarlo-glance.js",
-        "remote_location": "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/www/aarlo-glance.js",
+        "local_location": "/custom_components/aarlo/pyarlo/__init__.py",
+        "remote_location": "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyarlo/__init__.py",
         "visit_repo": "https://github.com/rccoleman/hass-aarlo",
-        "changelog": "https://github.com/rccoleman/hass-aarlo/blob/master/changelog"
+        "changelog": "https://github.com/rccoleman/hass-aarlo/blob/master/changelog",
+        "resources": [
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/backend.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/storage.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/__init__.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/media.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/util.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/camera.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/background.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/sseclient.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/doorbell.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/base.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/constant.py",
+             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/device.py"
+        ]
     }
 }

--- a/custom_components.json
+++ b/custom_components.json
@@ -26,14 +26,13 @@
     },
     "pyarlo": {
         "version": "0.0.2",
-        "local_location": "/custom_components/aarlo/pyarlo/__init__.py",
+        "local_location": "/custom_components/aarlo/pyaarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyarlo/__init__.py",
         "visit_repo": "https://github.com/rccoleman/hass-aarlo",
         "changelog": "https://github.com/rccoleman/hass-aarlo/blob/master/changelog",
         "resources": [
              "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/backend.py",
              "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/storage.py",
-             "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/__init__.py",
              "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/media.py",
              "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/util.py",
              "https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/aarlo/pyaarlo/camera.py",


### PR DESCRIPTION
This PR adds support for tracking updates to the component and card and allowing for easier updates via the Lovelace tracker card.  The following changes need to be made:

In configuration.yaml:

```
custom_updater:
  track:
    - components
    - cards
  component_urls:
    - https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/custom_components.json
  card_urls:
    - https://raw.githubusercontent.com/rccoleman/hass-aarlo/master/custom_cards.json
```

In ui-lovelace.yaml:

```
resources:
  - type: module
    url: /customcards/aarlo-glance.js?track=true
```

Ideally the components and cards would be added to the official list to avoid the need to make these changes:

> https://raw.githubusercontent.com/custom-cards/information/master/repos.json
> https://raw.githubusercontent.com/custom-components/information/master/repos.json

as described here: https://github.com/custom-components/custom_updater/wiki/How-it-works

Version numbers and repo file locations will obviously need to be changed.