### PR TITLE
0.0.9: add timestamp to device request

### DIFF
--- a/aarlo/__init__.py
+++ b/aarlo/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.const import (
         CONF_USERNAME, CONF_PASSWORD, CONF_SCAN_INTERVAL)
 
-__version__ = '0.0.8'
+__version__ = '0.0.9'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/aarlo/pyaarlo/__init__.py
+++ b/aarlo/pyaarlo/__init__.py
@@ -26,7 +26,7 @@ from custom_components.aarlo.pyaarlo.constant import ( BLANK_IMAGE,
 
 _LOGGER = logging.getLogger('pyaarlo')
 
-__version__ = '0.0.8'
+__version__ = '0.0.9'
 
 class PyArlo(object):
 

--- a/aarlo/pyaarlo/__init__.py
+++ b/aarlo/pyaarlo/__init__.py
@@ -14,6 +14,7 @@ from custom_components.aarlo.pyaarlo.media import ArloMediaLibrary
 from custom_components.aarlo.pyaarlo.base import ArloBase
 from custom_components.aarlo.pyaarlo.camera import ArloCamera
 from custom_components.aarlo.pyaarlo.doorbell import ArloDoorBell
+from custom_components.aarlo.pyaarlo.util import time_to_arlotime
 
 from custom_components.aarlo.pyaarlo.constant import ( BLANK_IMAGE,
                                 DEVICE_KEYS,
@@ -67,7 +68,7 @@ class PyArlo(object):
         # slow piece.
         # get devices and fill local db, and create device instance
         self.info('pyaarlo starting')
-        self._devices = self._be.get( DEVICES_URL )
+        self._devices = self._be.get( DEVICES_URL + "?t={}".format(time_to_arlotime()) )
         self._parse_devices()
         for device in self._devices:
             dname = device.get('deviceName')

--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@
 0.0.2: Added manifest to aarlo
 
 aarlo:
+0.0.9: mirror pyaarlo version
 0.0.8: mirror pyaarlo version
 0.0.7: mirror pyaarlo version
 0.0.6: mirror pyaarlo version
@@ -9,6 +10,7 @@ aarlo:
 0.0.4: mirror pyaarlo version
 
 pyaarlo:
+0.0.9: Added timestamp to device request.
 0.0.8: Restore version 1 of the modes API because it is needed by ArloQ and Arlo Babycams.
 0.0.7: Fix race condition causing crash when initial login times out.
 0.0.6: Handle general exceptions when using requests.

--- a/custom_components.json
+++ b/custom_components.json
@@ -1,6 +1,6 @@
 {
     "aarlo": {
-        "version": "0.0.8",
+        "version": "0.0.9",
         "local_location": "/custom_components/aarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/__init__.py",
         "visit_repo": "https://github.com/twrecked/hass-aarlo",
@@ -15,7 +15,7 @@
         ]
     },
     "pyaarlo": {
-        "version": "0.0.8",
+        "version": "0.0.9",
         "local_location": "/custom_components/aarlo/pyaarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/__init__.py",
         "visit_repo": "https://github.com/twrecked/hass-aarlo",


### PR DESCRIPTION

Bring code into line with webapi which, when getting a list of devices, adds a timestamp.
