### PR TITLE
Fix enable and disable motion detection

### DIFF
--- a/aarlo/__init__.py
+++ b/aarlo/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.const import (
         CONF_USERNAME, CONF_PASSWORD, CONF_SCAN_INTERVAL)
 
-__version__ = '0.0.12'
+__version__ = '0.0.13'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/aarlo/camera.py
+++ b/aarlo/camera.py
@@ -279,16 +279,7 @@ class ArloCam(Camera):
 
     def set_base_station_mode(self, mode):
         """Set the mode in the base station."""
-        # Get the list of base stations identified by library
-        base_stations = self.hass.data[DATA_ARLO].base_stations
-
-        # Some Arlo cameras does not have base station
-        # So check if there is base station detected first
-        # if yes, then choose the primary base station
-        # Set the mode on the chosen base station
-        if base_stations:
-            primary_base_station = base_stations[0]
-            primary_base_station.mode = mode
+        self._camera.base_station.mode = mode
 
     def enable_motion_detection(self):
         """Enable the Motion detection in base station (Arm)."""

--- a/aarlo/pyaarlo/__init__.py
+++ b/aarlo/pyaarlo/__init__.py
@@ -26,7 +26,7 @@ from custom_components.aarlo.pyaarlo.constant import ( BLANK_IMAGE,
 
 _LOGGER = logging.getLogger('pyaarlo')
 
-__version__ = '0.0.12'
+__version__ = '0.0.13'
 
 class PyArlo(object):
 

--- a/aarlo/pyaarlo/device.py
+++ b/aarlo/pyaarlo/device.py
@@ -136,6 +136,9 @@ class ArloChildDevice(ArloDevice):
     def __init__( self,name,arlo,attrs ):
         super().__init__( name,arlo,attrs )
 
+        self._parent_id   = attrs.get('parentId',None)
+        self._arlo.debug( 'parent is {}'.format( self._parent_id ) )
+
     def _event_handler( self,resource,event ):
         self._arlo.debug( self.name + ' got ' + resource )
 
@@ -160,15 +163,24 @@ class ArloChildDevice(ArloDevice):
 
     @property
     def parent_id(self):
-        return self._arlo._st.get( [self._device_id,PARENT_ID_KEY],'UNKNOWN' )
+        if self._parentId is not None:
+            self._arlo.debug( 'real parent is {}'.format( self._parent_id ) )
+            return self._parentId
+        self._arlo.debug( 'fake parent is {}'.format( self.device_id ) )
+        return self.device_id
 
     @property
     def base_station(self):
+        # look for real parents
         for base in self._arlo.base_stations:
             if base.device_id == self.parent_id:
                 return base
         # some cameras don't have base stations... it's its own basestation...
-        return self
+        for base in self._arlo.base_stations:
+            if base.device_id == self.device_id:
+                return base
+        # no idea!
+        return self._arlo.base_stations[0]
 
     @property
     def battery_level(self):

--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@
 0.0.2: Added manifest to aarlo
 
 aarlo:
+0.0.13: Fix camera.(enable|disable)_motion service.
 0.0.12: Fixed stream_source() api
 0.0.11: Tidied docs, fleshed out services list.
 0.0.10: Added support for schedules.
@@ -13,6 +14,7 @@ aarlo:
 0.0.4: mirror pyaarlo version
 
 pyaarlo:
+0.0.13: Fix camera.(enable|disable)_motion service.
 0.0.12: mirror aarlo version
 0.0.11: mirror aarlo version
 0.0.10: Added support for schedules.

--- a/custom_components.json
+++ b/custom_components.json
@@ -1,6 +1,6 @@
 {
     "aarlo": {
-        "version": "0.0.12",
+        "version": "0.0.13",
         "local_location": "/custom_components/aarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/__init__.py",
         "visit_repo": "https://github.com/twrecked/hass-aarlo",
@@ -15,7 +15,7 @@
         ]
     },
     "pyaarlo": {
-        "version": "0.0.12",
+        "version": "0.0.13",
         "local_location": "/custom_components/aarlo/pyaarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/aarlo/pyaarlo/__init__.py",
         "visit_repo": "https://github.com/twrecked/hass-aarlo",


### PR DESCRIPTION

Fixed enable and disable motion detection. This works best where the camera is the base station - i.e. ArloQ and BabyCam cameras. It will work for other cameras but will enable/disable motion for all cameras associated with the base station.
