### PR TITLE
#68 Re-fetch device list when arm/disarm fails to hopefully make it stable

### DIFF
--- a/custom_components/aarlo/pyaarlo/backend.py
+++ b/custom_components/aarlo/pyaarlo/backend.py
@@ -8,9 +8,7 @@ import pprint
 
 #from sseclient import ( SSEClient )
 from custom_components.aarlo.pyaarlo.sseclient import ( SSEClient )
-from custom_components.aarlo.pyaarlo.util import time_to_arlotime
 from custom_components.aarlo.pyaarlo.constant import ( EVENT_STREAM_TIMEOUT,
-                                DEVICES_URL,
                                 LOGIN_URL,
                                 LOGOUT_URL,
                                 NOTIFY_URL,
@@ -320,8 +318,6 @@ class ArloBackEnd(object):
                 headers['User-Agent'] = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.81 Safari/537.36'
 
             self._session.headers.update(headers)
-            self._arlo.debug('Fetching device list after login (seems to make arming/disarming more stable)')
-            self.get( DEVICES_URL + "?t={}".format(time_to_arlotime()) )
             return True
 
     def is_connected( self ):

--- a/custom_components/aarlo/pyaarlo/base.py
+++ b/custom_components/aarlo/pyaarlo/base.py
@@ -3,6 +3,7 @@ from custom_components.aarlo.pyaarlo.device import ArloDevice
 
 from custom_components.aarlo.pyaarlo.util import ( time_to_arlotime )
 from custom_components.aarlo.pyaarlo.constant import ( AUTOMATION_URL,
+                                DEVICES_URL,
                                 DEFAULT_MODES,
                                 DEFINITIONS_URL,
                                 MODES_KEY,
@@ -145,12 +146,24 @@ class ArloBase(ArloDevice):
                                         "publishResponse":True,
                                         "properties":{"active":mode_id}} )
             else:
-                self._arlo._bg.run( self._arlo._be.post,url=AUTOMATION_URL,
-                                params={'activeAutomations':
-                                    [ {'deviceId':self.device_id,
-                                        'timestamp':time_to_arlotime(),
-                                        active:[mode_id],
-                                        inactive:[] } ] } )
+                def _set_mode_v2_cb():
+                    params = {'activeAutomations':
+                        [ {'deviceId':self.device_id,
+                            'timestamp':time_to_arlotime(),
+                            active:[mode_id],
+                            inactive:[] } ] }
+                    for i in range(1,3):
+                        body = self._arlo._be.post(url=AUTOMATION_URL, params=params, raw=True)
+                        if body['success']:
+                            return
+                        self._arlo.warning('attempt {0}: error in response when setting mode={1}'.format(i, str(body)))
+                        self._arlo.debug('Fetching device list (hoping this will fix arming/disarming)')
+                        self._arlo._be.get( DEVICES_URL + "?t={}".format(time_to_arlotime()) )
+                    self._arlo.error('Failed to set mode.')
+                    self._arlo.debug('Giving up on setting mode! Session headers=' + self._arlo._be._session.headers)
+                    self._arlo.debug('Giving up on setting mode! Session cookies=' + self._arlo._be._session.cookies)
+
+                self._arlo._bg.run(_set_mode_v2_cb)
         else:
             self._arlo.warning( '{0}: mode {1} is unrecognised'.format( self.name,mode_name) )
 


### PR DESCRIPTION
Testing a new approach to help make arming/disarming more stable. It seems that the error we're chasing (`Device doesn't belong to the User`) occurs both when re-logging in, as well as after some time (maybe if you hit a new CDN node, or some server-side session expires?). This new PR catches the error when it happens and does the thing that seems to repair state (list devices), and then re-tries the failed operation. I also added some extra debug logging should the second attempt fail where it will dump cookies + auth token into the debug log, this to get a shot at experimenting with a failed session externally to home assistant.