### PR TITLE
Remove call to close SSE stream on error (it hangs forever) #68

### DIFF
--- a/custom_components/aarlo/pyaarlo/backend.py
+++ b/custom_components/aarlo/pyaarlo/backend.py
@@ -73,10 +73,7 @@ class ArloBackEnd(object):
                 elif method == 'POST':
                     r = self._session.post(url, json=params, headers=headers, timeout=timeout)
         except Exception as e:
-            self._arlo.debug('request-error={}'.format(type(e).__name__))
-            if self._ev_stream is not None:
-                # self._ev_stream.close()
-                self._ev_stream.resp.close()
+            self._arlo.warning('request-error={}'.format(type(e).__name__))
             return None
 
         self._arlo.debug('finish request=' + str(r.status_code))


### PR DESCRIPTION
Update error handling for when we get a request error. Now, we warn
about the error but take no other action. The previous action had
issues where the close() call would never return, which hangs the
entire job scheduler.