### PR TITLE
Media Player: fix entities not showing in entity registry

### DIFF
--- a/custom_components/aarlo/media_player.py
+++ b/custom_components/aarlo/media_player.py
@@ -128,6 +128,11 @@ class ArloMediaPlayerDevice(MediaPlayerDevice):
         return self._name
 
     @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
+
+    @property
     def state(self):
         """Return the state of the device."""
         return self._state


### PR DESCRIPTION
Without the `unique_id` property, Arlo Baby media players do not show in the HA entity registry