### PR TITLE
Arlo light: add battery attributes to device state attributes

### DIFF
--- a/custom_components/aarlo/light.py
+++ b/custom_components/aarlo/light.py
@@ -18,7 +18,9 @@ from homeassistant.components.light import (
     SUPPORT_EFFECT,
     Light,
 )
-from homeassistant.const import (ATTR_ATTRIBUTION)
+from homeassistant.const import (ATTR_ATTRIBUTION,
+                                 ATTR_BATTERY_CHARGING,
+                                 ATTR_BATTERY_LEVEL)
 from homeassistant.core import callback
 import homeassistant.util.color as color_util
 from . import CONF_ATTRIBUTION, DATA_ARLO, DEFAULT_BRAND
@@ -30,6 +32,9 @@ from .pyaarlo.constant import (
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['aarlo']
+
+ATTR_BATTERY_TECH = 'battery_tech'
+ATTR_CHARGER_TYPE = 'charger_type'
 
 LIGHT_EFFECT_RAINBOW = "rainbow"
 LIGHT_EFFECT_NONE = "none"
@@ -95,7 +100,15 @@ class ArloLight(Light):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attrs = {}
+
+        attrs = {
+            name: value for name, value in (
+                (ATTR_BATTERY_LEVEL, self._light.battery_level),
+                (ATTR_BATTERY_TECH, self._light.battery_tech),
+                (ATTR_BATTERY_CHARGING, self._light.charging),
+                (ATTR_CHARGER_TYPE, self._light.charger_type),
+            ) if value is not None
+        }
 
         attrs[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
         attrs['brand'] = DEFAULT_BRAND


### PR DESCRIPTION
This adds the battery attributes to the entity device state attributes. This is useful for scripts which check `battery_level` attributes on devices (the `sensor.battery_level_*` entities don't have these).

This also follows convention as described in the [Home Assistant Docs](https://developers.home-assistant.io/docs/en/entity_index.html#standard-attributes)

<img width="392" alt="Screen Shot 2020-02-13 at 2 41 47 pm" src="https://user-images.githubusercontent.com/81972/74399518-2f4af780-4e6f-11ea-8a01-89dd1db0310e.png">
<img width="392" alt="Screen Shot 2020-02-13 at 2 41 24 pm" src="https://user-images.githubusercontent.com/81972/74399520-3245e800-4e6f-11ea-856b-a327eee91383.png">
<img width="392" alt="Screen Shot 2020-02-13 at 2 41 31 pm" src="https://user-images.githubusercontent.com/81972/74399521-32de7e80-4e6f-11ea-9400-ceea86ccdc0e.png">
