### PR TITLE
Fix link to twrecked GitHub user

### DIFF
--- a/custom_components/aarlo/manifest.json
+++ b/custom_components/aarlo/manifest.json
@@ -3,6 +3,6 @@
   "name": "Arlo Camera Support",
   "documentation": "https://github.com/twrecked/hass-aarlo/blob/master/README.md",
   "dependencies": ["ffmpeg"],
-  "codeowners": ["@sherrell"],
+  "codeowners": ["@twrecked"],
   "requirements": []
 }


### PR DESCRIPTION
Currently when looking at the list of Authors in HACS it links to a different [sherrell](https://github.com/sherrell) user.