### PR TITLE
moved to unique keys

### DIFF
--- a/custom_components/aarlo/pyaarlo/__init__.py
+++ b/custom_components/aarlo/pyaarlo/__init__.py
@@ -11,7 +11,7 @@ from .background import ArloBackground
 from .base import ArloBase
 from .camera import ArloCamera
 from .cfg import ArloCfg
-from .constant import (BLANK_IMAGE, DEVICE_KEYS, DEVICES_PATH,
+from .constant import (BLANK_IMAGE, DEVICES_PATH,
                        FAST_REFRESH_INTERVAL, SLOW_REFRESH_INTERVAL,
                        TOTAL_BELLS_KEY, TOTAL_CAMERAS_KEY, TOTAL_LIGHTS_KEY, MEDIA_LIBRARY_DELAY,
                        REFRESH_CAMERA_DELAY, INITIAL_REFRESH_DELAY)
@@ -64,7 +64,6 @@ class PyArlo(object):
         # Get devices, fill local db, and create device instance.
         self.info('pyaarlo starting')
         self._refresh_devices()
-        self._parse_devices()
         for device in self._devices:
             dname = device.get('deviceName')
             dtype = device.get('deviceType')
@@ -112,15 +111,6 @@ class PyArlo(object):
     def _refresh_devices(self):
         self._devices = self._be.get(DEVICES_PATH + "?t={}".format(time_to_arlotime()))
         self.vdebug("devices={}".format(pprint.pformat(self._devices)))
-
-    def _parse_devices(self):
-        for device in self._devices:
-            device_id = device.get('deviceId', None)
-            if device_id is not None:
-                for key in DEVICE_KEYS:
-                    value = device.get(key, None)
-                    if value is not None:
-                        self._st.set([device_id, key], value)
 
     def _refresh_camera_thumbnails(self):
         """ Request latest camera thumbnails, called at start up. """

--- a/custom_components/aarlo/pyaarlo/backend.py
+++ b/custom_components/aarlo/pyaarlo/backend.py
@@ -60,9 +60,9 @@ class ArloBackEnd(object):
         try:
             with self._req_lock:
                 url = self._arlo.cfg.host + path
-                # self._arlo.debug('starting request=' + str(url))
-                # self._arlo.debug('starting request=' + str(params))
-                # self._arlo.debug('starting request=' + str(headers))
+                #self._arlo.vdebug('starting request=' + str(url))
+                #self._arlo.vdebug('starting request=' + str(params))
+                #self._arlo.vdebug('starting request=' + str(headers))
                 if method == 'GET':
                     r = self._session.get(url, params=params, headers=headers, stream=stream, timeout=timeout)
                     if stream is True:

--- a/custom_components/aarlo/pyaarlo/base.py
+++ b/custom_components/aarlo/pyaarlo/base.py
@@ -17,13 +17,13 @@ class ArloBase(ArloDevice):
         self._schedules = None
 
     def _id_to_name(self, mode_id):
-        return self._arlo.st.get([self.device_id, MODE_ID_TO_NAME_KEY, mode_id], None)
+        return self._load([MODE_ID_TO_NAME_KEY, mode_id], None)
 
     def _id_is_schedule(self, mode_id):
-        return self._arlo.st.get([self.device_id, MODE_IS_SCHEDULE_KEY, mode_id], False)
+        return self._load([MODE_IS_SCHEDULE_KEY, mode_id], False)
 
     def _name_to_id(self, mode_name):
-        return self._arlo.st.get([self.device_id, MODE_NAME_TO_ID_KEY, mode_name.lower()], None)
+        return self._load([MODE_NAME_TO_ID_KEY, mode_name.lower()], None)
 
     def _parse_modes(self, modes):
         for mode in modes:
@@ -35,9 +35,9 @@ class ArloBase(ArloDevice):
                     mode_name = mode_id
             if mode_id and mode_name != '':
                 self._arlo.debug(mode_id + '<=M=>' + mode_name)
-                self._arlo.st.set([self.device_id, MODE_ID_TO_NAME_KEY, mode_id], mode_name)
-                self._arlo.st.set([self.device_id, MODE_NAME_TO_ID_KEY, mode_name.lower()], mode_id)
-                self._arlo.st.set([self.device_id, MODE_IS_SCHEDULE_KEY, mode_name.lower()], False)
+                self._save([MODE_ID_TO_NAME_KEY, mode_id], mode_name)
+                self._save([MODE_NAME_TO_ID_KEY, mode_name.lower()], mode_id)
+                self._save([MODE_IS_SCHEDULE_KEY, mode_name.lower()], False)
 
     def schedule_to_modes(self):
         if self._schedules is None:
@@ -68,9 +68,9 @@ class ArloBase(ArloDevice):
                 schedule_name = schedule_id
             if schedule_id and schedule_name != '':
                 self._arlo.debug(schedule_id + '<=S=>' + schedule_name)
-                self._arlo.st.set([self.device_id, MODE_ID_TO_NAME_KEY, schedule_id], schedule_name)
-                self._arlo.st.set([self.device_id, MODE_NAME_TO_ID_KEY, schedule_name.lower()], schedule_id)
-                self._arlo.st.set([self.device_id, MODE_IS_SCHEDULE_KEY, schedule_name.lower()], True)
+                self._save([MODE_ID_TO_NAME_KEY, schedule_id], schedule_name)
+                self._save([MODE_NAME_TO_ID_KEY, schedule_name.lower()], schedule_id)
+                self._save([MODE_IS_SCHEDULE_KEY, schedule_name.lower()], True)
 
     def _event_handler(self, resource, event):
         self._arlo.debug(self.name + ' BASE got ' + resource)
@@ -141,7 +141,7 @@ class ArloBase(ArloDevice):
     @property
     def available_modes_with_ids(self):
         modes = {}
-        for key, mode_id in self._arlo.st.get_matching([self._device_id, MODE_NAME_TO_ID_KEY, '*']):
+        for key, mode_id in self._load_matching([MODE_NAME_TO_ID_KEY, '*']):
             modes[key.split('/')[-1]] = mode_id
         if not modes:
             modes = DEFAULT_MODES
@@ -149,7 +149,7 @@ class ArloBase(ArloDevice):
 
     @property
     def mode(self):
-        return self._arlo.st.get([self.device_id, MODE_KEY], 'unknown')
+        return self._load(MODE_KEY, 'unknown')
 
     @mode.setter
     def mode(self, mode_name):
@@ -221,7 +221,7 @@ class ArloBase(ArloDevice):
 
     @property
     def schedule(self):
-        return self._arlo.st.get([self.device_id, SCHEDULE_KEY], None)
+        return self._load(SCHEDULE_KEY, None)
 
     @property
     def on_schedule(self):
@@ -249,7 +249,7 @@ class ArloBase(ArloDevice):
 
     @property
     def siren_state(self):
-        return self._arlo.st.get([self._device_id, SIREN_STATE_KEY], "off")
+        return self._load(SIREN_STATE_KEY, "off")
 
     def siren_on(self, duration=300, volume=8):
         body = {

--- a/custom_components/aarlo/pyaarlo/camera.py
+++ b/custom_components/aarlo/pyaarlo/camera.py
@@ -78,8 +78,7 @@ class ArloCamera(ArloChildDevice):
                 self._lock.notify_all()
 
         # signal real mode, safe to call multiple times
-        self._save_and_do_callbacks(ACTIVITY_STATE_KEY,
-                                    self._arlo.st.get([self._device_id, ACTIVITY_STATE_KEY], 'unknown'))
+        self._save_and_do_callbacks(ACTIVITY_STATE_KEY, self._load(ACTIVITY_STATE_KEY, 'unknown'))
 
     def _update_media_and_thumbnail(self):
         self._arlo.debug('getting media image for ' + self.name)
@@ -96,7 +95,7 @@ class ArloCamera(ArloChildDevice):
         self._arlo.debug('getting image for ' + self.name)
 
         # Get image and date, if fails set to blank.
-        img, date = http_get_img(self._arlo.st.get([self.device_id, LAST_IMAGE_KEY], None))
+        img, date = http_get_img(self._load(LAST_IMAGE_KEY, None))
         if img is None:
             self._arlo.debug('using blank image for ' + self.name)
             img = self._arlo.blank_image
@@ -114,7 +113,7 @@ class ArloCamera(ArloChildDevice):
         self._arlo.debug('getting image for ' + self.name)
 
         # Get image and date, if fails ignore.
-        img, date = http_get_img(self._arlo.st.get([self.device_id, SNAPSHOT_KEY], None))
+        img, date = http_get_img(self._load(SNAPSHOT_KEY, None))
         if img is not None:
             date = date.strftime(self._arlo.cfg.last_format)
             self._save(LAST_IMAGE_SRC_KEY, 'snapshot/' + date)
@@ -264,16 +263,16 @@ class ArloCamera(ArloChildDevice):
 
     @property
     def last_image(self):
-        return self._arlo.st.get([self._device_id, LAST_IMAGE_KEY], None)
+        return self._load(LAST_IMAGE_KEY, None)
 
     # fill this out...
     @property
     def last_image_from_cache(self):
-        return self._arlo.st.get([self._device_id, LAST_IMAGE_DATA_KEY], self._arlo.blank_image)
+        return self._load(LAST_IMAGE_DATA_KEY, self._arlo.blank_image)
 
     @property
     def last_image_source(self):
-        return self._arlo.st.get([self._device_id, LAST_IMAGE_SRC_KEY], '')
+        return self._load(LAST_IMAGE_SRC_KEY, '')
 
     @property
     def last_video(self):
@@ -290,7 +289,7 @@ class ArloCamera(ArloChildDevice):
 
     @property
     def last_capture(self):
-        return self._arlo.st.get([self._device_id, LAST_CAPTURE_KEY], None)
+        return self._load(LAST_CAPTURE_KEY, None)
 
     @property
     def last_capture_date_format(self):
@@ -298,31 +297,31 @@ class ArloCamera(ArloChildDevice):
 
     @property
     def brightness(self):
-        return self._arlo.st.get([self._device_id, BRIGHTNESS_KEY], None)
+        return self._load(BRIGHTNESS_KEY, None)
 
     @property
     def flip_state(self):
-        return self._arlo.st.get([self._device_id, FLIP_KEY], None)
+        return self._load(FLIP_KEY, None)
 
     @property
     def mirror_state(self):
-        return self._arlo.st.get([self._device_id, MIRROR_KEY], None)
+        return self._load(MIRROR_KEY, None)
 
     @property
     def motion_detection_sensitivity(self):
-        return self._arlo.st.get([self._device_id, MOTION_SENS_KEY], None)
+        return self._load(MOTION_SENS_KEY, None)
 
     @property
     def powersave_mode(self):
-        return self._arlo.st.get([self._device_id, POWER_SAVE_KEY], None)
+        return self._load(POWER_SAVE_KEY, None)
 
     @property
     def unseen_videos(self):
-        return self._arlo.st.get([self._device_id, MEDIA_COUNT_KEY], 0)
+        return self._load(MEDIA_COUNT_KEY, 0)
 
     @property
     def captured_today(self):
-        return self._arlo.st.get([self._device_id, CAPTURED_TODAY_KEY], 0)
+        return self._load(CAPTURED_TODAY_KEY, 0)
 
     @property
     def min_days_vdo_cache(self):
@@ -433,15 +432,15 @@ class ArloCamera(ArloChildDevice):
     def is_taking_snapshot(self):
         if self._snapshot_state != 'idle':
             return True
-        return self._arlo.st.get([self._device_id, ACTIVITY_STATE_KEY], 'unknown') == 'fullFrameSnapshot'
+        return self._load(ACTIVITY_STATE_KEY, 'unknown') == 'fullFrameSnapshot'
 
     @property
     def is_recording(self):
-        return self._arlo.st.get([self._device_id, ACTIVITY_STATE_KEY], 'unknown') == 'alertStreamActive'
+        return self._load(ACTIVITY_STATE_KEY, 'unknown') == 'alertStreamActive'
 
     @property
     def is_streaming(self):
-        return self._arlo.st.get([self._device_id, ACTIVITY_STATE_KEY], 'unknown') == 'userStreamActive'
+        return self._load(ACTIVITY_STATE_KEY, 'unknown') == 'userStreamActive'
 
     @property
     def was_recently_active(self):
@@ -523,7 +522,7 @@ class ArloCamera(ArloChildDevice):
 
     @property
     def siren_state(self):
-        return self._arlo.st.get([self._device_id, SIREN_STATE_KEY], "off")
+        return self._load(SIREN_STATE_KEY, "off")
 
     def siren_on(self, duration=300, volume=8):
         body = {
@@ -545,7 +544,7 @@ class ArloCamera(ArloChildDevice):
 
     @property
     def is_on(self):
-        return not self._arlo.st.get([self._device_id, PRIVACY_KEY], False)
+        return not self._load(PRIVACY_KEY, False)
 
     def turn_on(self):
         self._arlo.bg.run(self._arlo.be.async_on_off, base=self.base_station, device=self, privacy_on=False)

--- a/custom_components/aarlo/pyaarlo/device.py
+++ b/custom_components/aarlo/pyaarlo/device.py
@@ -2,7 +2,7 @@ import pprint
 import threading
 
 from .constant import (BATTERY_KEY, BATTERY_TECH_KEY, CHARGING_KEY, CHARGER_KEY,
-                       CONNECTION_KEY, RESOURCE_KEYS,
+                       CONNECTION_KEY, DEVICE_KEYS, RESOURCE_KEYS,
                        RESOURCE_UPDATE_KEYS, SIGNAL_STR_KEY,
                        XCLOUD_ID_KEY)
 
@@ -22,12 +22,25 @@ class ArloDevice(object):
         self._device_type = attrs.get('deviceType', 'unknown')
         self._unique_id = attrs.get('uniqueId', None)
 
+        # Build initial values... attrs is device state
+        for key in DEVICE_KEYS:
+            value = attrs.get(key, None)
+            if value is not None:
+                self._save(key, value)
+
         # add a listener
         self._arlo.be.add_listener(self, self._event_handler)
 
     def __repr__(self):
         # Representation string of object.
         return "<{0}:{1}:{2}>".format(self.__class__.__name__, self._device_type, self._name)
+
+    def _to_storage_key(self, attr):
+        # Build a key incorporating the type!
+        if isinstance(attr,list):
+            return [self.__class__.__name__, self._device_id] + attr
+        else:
+            return [self.__class__.__name__, self._device_id, attr]
 
     def _event_handler(self, resource, event):
         self._arlo.vdebug("{}: got {} event {}".format(self.name, resource, pprint.pformat(event)))
@@ -54,12 +67,17 @@ class ArloDevice(object):
 
     def _save(self, attr, value):
         # TODO only care if it changes?
-        key = [self.device_id, self.device_type, attr]
-        self._arlo.st.set(key, value)
+        self._arlo.st.set(self._to_storage_key(attr), value)
 
     def _save_and_do_callbacks(self, attr, value):
         self._save(attr, value)
         self._do_callbacks(attr, value)
+
+    def _load(self, attr, default=None):
+        return self._arlo.st.get(self._to_storage_key(attr), default)
+
+    def _load_matching(self, attr, default=None):
+        return self._arlo.st.get_matching(self._to_storage_key(attr), default)
 
     @property
     def name(self):
@@ -116,7 +134,7 @@ class ArloDevice(object):
 
     @property
     def xcloud_id(self):
-        return self._arlo.st.get([self._device_id, XCLOUD_ID_KEY], 'UNKNOWN')
+        return self._load(XCLOUD_ID_KEY, 'UNKNOWN')
 
     @property
     def web_id(self):
@@ -127,7 +145,7 @@ class ArloDevice(object):
         return self._unique_id
 
     def attribute(self, attr, default=None):
-        value = self._arlo.st.get([self._device_id, attr], None)
+        value = self._load(attr, None)
         if value is None:
             value = self._attrs.get(attr, None)
         if value is None:
@@ -202,19 +220,19 @@ class ArloChildDevice(ArloDevice):
 
     @property
     def battery_level(self):
-        return self._arlo.st.get([self._device_id, BATTERY_KEY], 100)
+        return self._load(BATTERY_KEY, 100)
 
     @property
     def battery_tech(self):
-        return self._arlo.st.get([self._device_id, BATTERY_TECH_KEY], 'None')
+        return self._load(BATTERY_TECH_KEY, 'None')
 
     @property
     def charging(self):
-        return self._arlo.st.get([self._device_id, CHARGING_KEY], 'off').lower() == 'on'
+        return self._load(CHARGING_KEY, 'off').lower() == 'on'
 
     @property
     def charger_type(self):
-        return self._arlo.st.get([self._device_id, CHARGER_KEY], 'None')
+        return self._load(CHARGER_KEY, 'None')
 
     @property
     def wired(self):
@@ -226,15 +244,15 @@ class ArloChildDevice(ArloDevice):
 
     @property
     def signal_strength(self):
-        return self._arlo.st.get([self._device_id, SIGNAL_STR_KEY], 3)
+        return self._load(SIGNAL_STR_KEY, 3)
 
     @property
     def is_unavailable(self):
-        return self._arlo.st.get([self._device_id, CONNECTION_KEY], 'unknown') == 'unavailable'
+        return self._load(CONNECTION_KEY, 'unknown') == 'unavailable'
 
     @property
     def too_cold(self):
-        return self._arlo.st.get([self._device_id, CONNECTION_KEY], 'unknown') == 'thermalShutdownCold'
+        return self._load(CONNECTION_KEY, 'unknown') == 'thermalShutdownCold'
 
     @property
     def state(self):

--- a/custom_components/aarlo/pyaarlo/light.py
+++ b/custom_components/aarlo/pyaarlo/light.py
@@ -22,7 +22,7 @@ class ArloLight(ArloChildDevice):
 
     @property
     def is_on(self):
-        return self._arlo.st.get([self._device_id, LAMP_STATE_KEY], "off") == "on"
+        return self._load(LAMP_STATE_KEY, "off") == "on"
 
     def turn_on(self, brightness=None, rgb=None):
 


### PR DESCRIPTION

Stop sharing state information between objects. The affects devices that appear as both a base station and a camera (or other device.)

State information no includes the device type to differentiate between objects. So:

```
XXXXXXXXX/ActiveState 
```

now splits into

```
ArloCamera/XXXXXXXXX/ActiveState 
ArloBase/XXXXXXXXX/ActiveState 
```
