### PR TITLE
add request snapshot service

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,5 @@
 aarlo/pyaarlo
+0.6.17: Add request_snapshot webservice
 0.6.16: Fix last_image so lovelace card works
         Arlo Baby: fix effect switching
 0.6.15: Copied services into aarlo domain

--- a/custom_components.json
+++ b/custom_components.json
@@ -1,6 +1,6 @@
 {
     "aarlo": {
-        "version": "0.6.16",
+        "version": "0.6.17",
         "local_location": "/custom_components/aarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/custom_components/aarlo/__init__.py",
         "visit_repo": "https://github.com/twrecked/hass-aarlo",
@@ -18,7 +18,7 @@
         ]
     },
     "pyaarlo": {
-        "version": "0.6.16",
+        "version": "0.6.17",
         "local_location": "/custom_components/aarlo/pyaarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/custom_components/aarlo/pyaarlo/__init__.py",
         "visit_repo": "https://github.com/twrecked/hass-aarlo",

--- a/custom_components/aarlo/__init__.py
+++ b/custom_components/aarlo/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
 from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_DOMAIN
 
-__version__ = '0.6.16'
+__version__ = '0.6.17'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/aarlo/pyaarlo/__init__.py
+++ b/custom_components/aarlo/pyaarlo/__init__.py
@@ -23,7 +23,7 @@ from .util import time_to_arlotime
 
 _LOGGER = logging.getLogger('pyaarlo')
 
-__version__ = '0.6.16'
+__version__ = '0.6.17'
 
 
 class PyArlo(object):


### PR DESCRIPTION

Provide a web service that starts a snapshot but doesn't wait for it to finish.

This allows me to streamline the lovelace card and stop passing unnecessary traffic over the websocket.
