### PR TITLE
Remove extreme debugging from alarm_control_panel

### DIFF
--- a/custom_components/aarlo/alarm_control_panel.py
+++ b/custom_components/aarlo/alarm_control_panel.py
@@ -214,7 +214,6 @@ class ArloBaseStation(AlarmControlPanel):
         """Make this non-dynamic later..."""
         try:
             c = __import__("homeassistant.components.alarm_control_panel.const",fromlist=['SUPPORT_ALARM_ARM_HOME', 'SUPPORT_ALARM_ARM_AWAY', 'SUPPORT_ALARM_ARM_NIGHT', 'SUPPORT_ALARM_TRIGGER'])
-            _LOGGER.debug('supported: ' + str(c.SUPPORT_ALARM_ARM_HOME | c.SUPPORT_ALARM_ARM_AWAY | c.SUPPORT_ALARM_ARM_NIGHT | c.SUPPORT_ALARM_TRIGGER))
             return c.SUPPORT_ALARM_ARM_HOME | c.SUPPORT_ALARM_ARM_AWAY | c.SUPPORT_ALARM_ARM_NIGHT | c.SUPPORT_ALARM_TRIGGER
         except ModuleNotFoundError:
             _LOGGER.debug('not supported')


### PR DESCRIPTION
Removed this logging, as it didn't seem useful. In a period of 24 hours this added 12,000 debug lines to my HA log 🙈.

Separately, I'm curious to understand why these imports are being done dynamically. Is it to support an older version of HA which didn't support these features?