### PR TITLE
Check if doorbell is base station

### DIFF
--- a/custom_components/aarlo/pyaarlo/__init__.py
+++ b/custom_components/aarlo/pyaarlo/__init__.py
@@ -71,10 +71,15 @@ class PyArlo(object):
                 self.info('skipping ' + dname + ': state unknown')
                 continue
 
+            # This needs it's own code now... Does no parent indicate a base station???
             if dtype == 'basestation' or \
-                    device.get('modelId') == 'ABC1000' or dtype == 'arloq' or dtype == 'arloqs' or \
-                    device.get('modelId').startswith('AVD1001'):
+                    device.get('modelId') == 'ABC1000' or dtype == 'arloq' or dtype == 'arloqs':
                 self._bases.append(ArloBase(dname, self, device))
+            # video doorbell can be its own base station, it can also be assigned to a real base station
+            if device.get('modelId').startswith('AVD1001'):
+                parent_id = device.get('parentId', None)
+                if parent_id is None or parent_id == device.get('deviceId', None):
+                    self._bases.append(ArloBase(dname, self, device))
             if dtype == 'arlobridge':
                 self._bases.append(ArloBase(dname, self, device))
             if dtype == 'camera' or dtype == 'arloq' or dtype == 'arloqs' or \


### PR DESCRIPTION

Before we'd blindly create a base station for a doorbell but a recent firmware update makes this optional. This is a possible fix.
