### PR TITLE
0.6.x session call

### DIFF
--- a/custom_components/aarlo/camera.py
+++ b/custom_components/aarlo/camera.py
@@ -294,9 +294,10 @@ class ArloCam(Camera):
         self._recent = False
         self._motion_status = False
         self._ffmpeg_arguments = config.get(CONF_FFMPEG_ARGUMENTS)
-        self.stream_options = { 'use_wallclock_as_timestamps': 1,
-                                'rtsp_flags': 'prefer_tcp',
-                                'stimeout': '5000000', }
+        #Arlo Q experiment
+        #self.stream_options = { 'use_wallclock_as_timestamps': 1,
+                                #'rtsp_flags': 'prefer_tcp',
+                                #'stimeout': '5000000', }
 
         _LOGGER.info('ArloCam: %s created', self._name)
 

--- a/custom_components/aarlo/pyaarlo/backend.py
+++ b/custom_components/aarlo/pyaarlo/backend.py
@@ -9,7 +9,7 @@ import uuid
 import base64
 
 from .constant import (AUTH_HOST, AUTH_PATH, AUTH_VALIDATE_PATH,
-                       DEFAULT_RESOURCES, LOGIN_PATH, LOGOUT_PATH,
+                       DEFAULT_RESOURCES, LOGIN_PATH, LOGOUT_PATH, SESSION_PATH,
                        NOTIFY_PATH, SUBSCRIBE_PATH, TRANSID_PREFIX, DEVICES_PATH)
 from .sseclient import SSEClient
 from .util import time_to_arlotime, now_strftime
@@ -420,6 +420,11 @@ class ArloBackEnd(object):
                                      'Chrome/72.0.3626.81 Safari/537.36')
 
         self._session.headers.update(headers)
+
+        session = self.get(SESSION_PATH)
+        if (session is None):
+            self._arlo.debug('session failed')
+            return False
 
         return True
 

--- a/custom_components/aarlo/pyaarlo/constant.py
+++ b/custom_components/aarlo/pyaarlo/constant.py
@@ -5,6 +5,7 @@ DEFINITIONS_PATH = '/hmsweb/users/automation/definitions'
 AUTOMATION_PATH = '/hmsweb/users/devices/automation/active'
 LIBRARY_PATH = '/hmsweb/users/library'
 LOGIN_PATH = '/hmsweb/login/v2'
+SESSION_PATH = "/hmsweb/users/session/v2"
 LOGOUT_PATH = '/hmsweb/logout'
 NOTIFY_PATH = '/hmsweb/users/devices/notify/'
 #SUBSCRIBE_PATH = '/hmsweb/client/subscribe?token='


### PR DESCRIPTION

Add session call. This will fix the "Arlo taking too long" messages.
  
Remove stream settings. This will start the streams working again.
