### PR TITLE
Change play_track to allow for resuming current track if no track_id is sent

### DIFF
--- a/custom_components/aarlo/media_player.py
+++ b/custom_components/aarlo/media_player.py
@@ -219,7 +219,7 @@ class ArloMediaPlayerDevice(MediaPlayerDevice):
 
     def media_play(self):
         """Send play command."""
-        self._device.unpause_track()
+        self._device.play_track()
         self._state = STATE_PLAYING
 
     def media_pause(self):

--- a/custom_components/aarlo/media_player.py
+++ b/custom_components/aarlo/media_player.py
@@ -219,7 +219,7 @@ class ArloMediaPlayerDevice(MediaPlayerDevice):
 
     def media_play(self):
         """Send play command."""
-        self._device.play_track()
+        self._device.unpause_track()
         self._state = STATE_PLAYING
 
     def media_pause(self):

--- a/custom_components/aarlo/pyaarlo/camera.py
+++ b/custom_components/aarlo/pyaarlo/camera.py
@@ -622,6 +622,14 @@ class ArloCamera(ArloChildDevice):
             }
         }
         self._arlo.bg.run(self._arlo.be.notify, base=self, body=body)
+    
+    def unpause_track(self):
+        body = {
+            'action': 'play',
+            'publishResponse': True,
+            'resource': MEDIA_PLAYER_RESOURCE_ID,
+        }
+        self._arlo.bg.run(self._arlo.be.notify, base=self, body=body)
 
     def pause_track(self):
         body = {

--- a/custom_components/aarlo/pyaarlo/camera.py
+++ b/custom_components/aarlo/pyaarlo/camera.py
@@ -610,25 +610,25 @@ class ArloCamera(ArloChildDevice):
             'resource': 'audioPlayback'
         }
         self._arlo.bg.run(self._arlo.be.notify, base=self, body=body)
-
-    def play_track(self, track_id=DEFAULT_TRACK_ID, position=0):
-        body = {
-            'action': 'playTrack',
-            'publishResponse': True,
-            'resource': MEDIA_PLAYER_RESOURCE_ID,
-            'properties': {
-                AUDIO_TRACK_KEY: track_id,
-                AUDIO_POSITION_KEY: position
-            }
-        }
-        self._arlo.bg.run(self._arlo.be.notify, base=self, body=body)
     
-    def unpause_track(self):
+    def play_track(self, track_id=None, position=0):
         body = {
-            'action': 'play',
             'publishResponse': True,
             'resource': MEDIA_PLAYER_RESOURCE_ID,
         }
+
+        if track_id is not None:
+            body.update({
+                'action': 'playTrack',
+                'properties': {
+                    AUDIO_TRACK_KEY: track_id,
+                    AUDIO_POSITION_KEY: position
+                }
+            })
+        else:
+            body.update({
+                'action': 'play',
+            })
         self._arlo.bg.run(self._arlo.be.notify, base=self, body=body)
 
     def pause_track(self):


### PR DESCRIPTION
When using action `play_pause`, with no media file specified, the play command would never unpause. Updating the `play` action to a new `unpause_track` method allows for functionality like a toggle to control the playback state of Arlo Baby.

My use case: we have the white noise on the camera for our kid, want to be able to toggle as a switch.