### PR TITLE
Fix floodlight capabilities

### DIFF
--- a/custom_components/aarlo/pyaarlo/camera.py
+++ b/custom_components/aarlo/pyaarlo/camera.py
@@ -964,11 +964,11 @@ class ArloCamera(ArloChildDevice):
             return True
         if cap in (AUDIO_DETECTED_KEY,):
             if self.model_id.startswith(
-                ('arloq', 'VMC4030', 'VMC4040', 'VMC5040', 'ABC1000', 'FB1001A')
+                ('arloq', 'VMC4030', 'VMC4040', 'VMC5040', 'ABC1000', 'FB1001')
             ):
                 return True
         if cap in (SIREN_STATE_KEY,):
-            if self.model_id.startswith(('VMC4040', 'VMC5040', 'FB1001A')):
+            if self.model_id.startswith(('VMC4040', 'VMC5040', 'FB1001')):
                 return True
         if cap in (SPOTLIGHT_KEY,):
             if self.model_id.startswith(('VMC4040', 'VMC5040')):
@@ -980,6 +980,6 @@ class ArloCamera(ArloChildDevice):
             if self.model_id.startswith('ABC1000'):
                 return True
         if cap in (FLOODLIGHT_KEY,):
-            if self.model_id.startswith('FB1001A'):
+            if self.model_id.startswith('FB1001'):
                 return True
         return super().has_capability(cap)


### PR DESCRIPTION
Seems like either 
- The model ID might be different depending on if you pair with a smarthub or directly to wifi
or
- Production and Staging had different model ids

My floodlight is showing as model_id `FB1001B` on production and connected to my smarthub.