### PR TITLE
Fixed recording duration.

### DIFF
--- a/custom_components/aarlo/camera.py
+++ b/custom_components/aarlo/camera.py
@@ -21,10 +21,18 @@ from homeassistant.components.camera import (ATTR_FILENAME,
                                              STATE_RECORDING,
                                              STATE_STREAMING,
                                              Camera)
+from homeassistant.components.stream.const import (
+    CONF_DURATION,
+    CONF_LOOKBACK,
+    CONF_STREAM_SOURCE,
+    DOMAIN as DOMAIN_STREAM,
+    SERVICE_RECORD,
+)
 from homeassistant.components.ffmpeg import DATA_FFMPEG
 from homeassistant.const import (ATTR_ATTRIBUTION,
                                  ATTR_BATTERY_LEVEL,
-                                 ATTR_ENTITY_ID)
+                                 ATTR_ENTITY_ID,
+                                 CONF_FILENAME)
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_aiohttp_proxy_stream
@@ -532,21 +540,20 @@ class ArloCam(Camera):
     def async_siren_off(self):
         return self.hass.async_add_job(self.siren_off)
 
-    def start_recording(self, duration):
-
-        def _stop_recording(_now):
-            self.stop_recording()
-
-        if self._camera.get_stream() is not None:
-            self._camera.start_recording()
-            async_track_point_in_time(self.hass, _stop_recording, dt_util.utcnow() + timedelta(seconds=duration))
+    def start_recording(self, duration=30):
+        source = self._camera.get_stream()
+        if source is not None:
+            self._camera.start_recording(duration=duration)
+        else:
+            _LOGGER.warning("failed to start recording for {}".self._camera.name)
+        return source
 
     def stop_recording(self):
         self._camera.stop_recording()
         self._camera.stop_activity()
 
     def async_start_recording(self, duration):
-        return self.hass.async_add_job(self.start_recording, duration=duration)
+        return self.hass.async_add_job(self.start_recording, duration)
 
     def async_stop_recording(self):
         return self.hass.async_add_job(self.stop_recording)
@@ -895,7 +902,28 @@ async def async_camera_start_recording_service(hass, call):
     for entity_id in call.data['entity_id']:
         duration = call.data[ATTR_DURATION]
         _LOGGER.info("{} start recording(duration={})".format(entity_id,duration))
-        get_entity_from_domain(hass,DOMAIN,entity_id).start_recording(duration=duration)
+        camera = get_entity_from_domain(hass, DOMAIN, entity_id)
+        source = await camera.async_start_recording(duration=duration)
+
+        # Longer than 25 seconds means we need to attach a stream and record to disk to keep
+        # Arlo recording.
+        if source is not None and duration > 25:
+            _LOGGER.info("{} attaching hidden stream for duration {}".format(entity_id, duration))
+
+            #  filename = "/tmp/scratch-{}.mp4".format(entity_id)
+            #  filename.hass = hass
+            #  video_path = filename.async_render(variables={ATTR_ENTITY_ID: camera})
+            video_path = "/tmp/scratch-{}.mp4".format(entity_id)
+
+            data = {
+                CONF_STREAM_SOURCE: source,
+                CONF_FILENAME: video_path,
+                CONF_DURATION: duration,
+                CONF_LOOKBACK: 0,
+            }
+            await hass.services.async_call(
+                DOMAIN_STREAM, SERVICE_RECORD, data, blocking=True, context=call.context
+            )
 
 
 async def async_camera_stop_recording_service(hass, call):

--- a/custom_components/aarlo/pyaarlo/camera.py
+++ b/custom_components/aarlo/pyaarlo/camera.py
@@ -523,7 +523,7 @@ class ArloCamera(ArloChildDevice):
                           })
         return True
 
-    def start_recording(self, duration=None):
+    def start_recording(self, duration=30):
         body = {
             'parentId': self.parent_id,
             'deviceId': self.device_id,
@@ -535,7 +535,7 @@ class ArloCamera(ArloChildDevice):
                           headers={"xcloudId": self.xcloud_id})
         if duration is not None:
             self._arlo.debug('queueing stop')
-            self._arlo.bg.run_in(self.stop_recording)
+            self._arlo.bg.run_in(self.stop_recording,duration)
 
     def stop_recording(self):
         body = {

--- a/custom_components/aarlo/services.yaml
+++ b/custom_components/aarlo/services.yaml
@@ -40,6 +40,9 @@ camera_start_recording:
     entity_id:
       description: Name(s) of entities to use
       example: 'camera.aarlo_front_camera'
+    duration:
+      description: duration to record for in seconds
+      example: 30
 
 camera_stop_recording:
   description: Request a camera stop recording to cloud


### PR DESCRIPTION
Allow recording duration of longer than 30 seconds by starting a stream
to the Arlo system. And writing the stream to a local tmp file.