### PR TITLE
Quiet down direct i/o message.

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ aarlo/pyaarlo
 0.6.18: Fix siren_on service call when entity_id is an Arlo ultra camera
         no_media_upload now working on more streams
         fixed recording duration
+        Fix direct i/o messages
 0.6.17: Add request_snapshot webservice
 0.6.16: Fix last_image so lovelace card works
         Arlo Baby: fix effect switching

--- a/custom_components/aarlo/camera.py
+++ b/custom_components/aarlo/camera.py
@@ -311,7 +311,7 @@ class ArloCam(Camera):
 
     async def stream_source(self):
         """Return the source of the stream."""
-        return self._camera.get_stream()
+        return await self.hass.async_add_executor_job(self._camera.get_stream)
 
     def async_stream_source(self):
         return self.hass.async_add_job(self.stream_source)


### PR DESCRIPTION
Quiet down the "Detected I/O inside the event loop" message throw out by
camera instances.
