### PR TITLE
Fixed deprecated device warnings.

### DIFF
--- a/custom_components/aarlo/alarm_control_panel.py
+++ b/custom_components/aarlo/alarm_control_panel.py
@@ -15,7 +15,7 @@ import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 from homeassistant.components import websocket_api
 from homeassistant.components.alarm_control_panel import (DOMAIN,
-                                                          AlarmControlPanel,
+                                                          AlarmControlPanelEntity,
                                                           FORMAT_NUMBER,
                                                           FORMAT_TEXT)
 from homeassistant.components.alarm_control_panel.const import (
@@ -169,7 +169,7 @@ async def async_setup_platform(hass, config, async_add_entities, _discovery_info
         )
 
 
-class ArloBaseStation(AlarmControlPanel):
+class ArloBaseStation(AlarmControlPanelEntity):
     """Representation of an Arlo Alarm Control Panel."""
 
     def __init__(self, device, config):

--- a/custom_components/aarlo/binary_sensor.py
+++ b/custom_components/aarlo/binary_sensor.py
@@ -9,7 +9,7 @@ import logging
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.binary_sensor import (BinarySensorDevice)
+from homeassistant.components.binary_sensor import (BinarySensorEntity)
 from homeassistant.const import (ATTR_ATTRIBUTION,
                                  CONF_MONITORED_CONDITIONS)
 from homeassistant.core import callback
@@ -55,7 +55,7 @@ async def async_setup_platform(hass, config, async_add_entities, _discovery_info
     async_add_entities(sensors, True)
 
 
-class ArloBinarySensor(BinarySensorDevice):
+class ArloBinarySensor(BinarySensorEntity):
     """An implementation of a Netgear Arlo IP sensor."""
 
     def __init__(self, device, sensor_type):

--- a/custom_components/aarlo/light.py
+++ b/custom_components/aarlo/light.py
@@ -17,7 +17,7 @@ from homeassistant.components.light import (
     SUPPORT_COLOR,
     SUPPORT_COLOR_TEMP,
     SUPPORT_EFFECT,
-    Light,
+    LightEntity,
 )
 from homeassistant.const import (ATTR_ATTRIBUTION,
                                  ATTR_BATTERY_CHARGING,
@@ -63,7 +63,7 @@ async def async_setup_platform(hass, _config, async_add_entities, _discovery_inf
     async_add_entities(lights, True)
 
 
-class ArloLight(Light):
+class ArloLight(LightEntity):
 
     def __init__(self, light):
         """Initialize an Arlo light."""

--- a/custom_components/aarlo/switch.py
+++ b/custom_components/aarlo/switch.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
-from homeassistant.components.switch import SwitchDevice
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import callback
 from homeassistant.helpers.config_validation import (PLATFORM_SCHEMA)
 from homeassistant.helpers.event import track_point_in_time
@@ -83,7 +83,7 @@ async def async_setup_platform(hass, config, async_add_entities, _discovery_info
     async_add_entities(devices, True)
 
 
-class AarloSwitch(SwitchDevice):
+class AarloSwitch(SwitchEntity):
     """Representation of a Aarlo switch."""
 
     def __init__(self, name, icon):

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,4 @@
+{
+  "name": "Arlo Camera Support",
+  "homeassistant": "0.110.0"
+}


### PR DESCRIPTION
Home Assistant 0.110.0 renamed some base components. This fix modifies
the Aarlo code to use them.

Added hacs.json to specify minimum version.
