### PR TITLE
Workaround camera stream issue on Homekit.

### DIFF
--- a/custom_components/aarlo/__init__.py
+++ b/custom_components/aarlo/__init__.py
@@ -9,6 +9,7 @@ import logging
 import json
 import pprint
 from datetime import timedelta
+from traceback import extract_stack
 
 import voluptuous as vol
 from requests.exceptions import HTTPError, ConnectTimeout
@@ -243,6 +244,17 @@ def get_entity_from_domain(hass, domain, entity_id):
         raise HomeAssistantError("{} component not set up".format(domain))
 
     return component.get_entity(entity_id)
+
+def is_homekit():
+    for frame in reversed(extract_stack()):
+        try:
+            frame.filename.index("homeassistant/components/homekit")
+            _LOGGER.debug("homekit detected")
+            return True
+        except ValueError:
+            continue
+    _LOGGER.debug("not homekit detected")
+    return False
 
 
 async def async_aarlo_siren_on(hass, call):

--- a/custom_components/aarlo/camera.py
+++ b/custom_components/aarlo/camera.py
@@ -38,7 +38,8 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_aiohttp_proxy_stream
 from homeassistant.helpers.config_validation import (PLATFORM_SCHEMA)
 from homeassistant.helpers.event import async_track_point_in_time
-from . import COMPONENT_ATTRIBUTION, COMPONENT_DATA, COMPONENT_BRAND, COMPONENT_DOMAIN, COMPONENT_SERVICES, get_entity_from_domain
+from . import COMPONENT_ATTRIBUTION, COMPONENT_DATA, COMPONENT_BRAND, COMPONENT_DOMAIN, COMPONENT_SERVICES, \
+    get_entity_from_domain, is_homekit
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -311,7 +312,10 @@ class ArloCam(Camera):
 
     async def stream_source(self):
         """Return the source of the stream."""
-        return await self.hass.async_add_executor_job(self._camera.get_stream)
+        if is_homekit():
+            return self._camera.get_stream()
+        else:
+            return await self.hass.async_add_executor_job(self._camera.get_stream)
 
     def async_stream_source(self):
         return self.hass.async_add_job(self.stream_source)


### PR DESCRIPTION
Homekit doesn't like the `add_executor_job` call. Code now detects if
we're inside a Homekit device and drops back to the old mechanism.

This needs a better solution.