### PR TITLE
Fix arloq audio detection.

### DIFF
--- a/custom_components/aarlo/pyaarlo/camera.py
+++ b/custom_components/aarlo/pyaarlo/camera.py
@@ -1152,8 +1152,9 @@ class ArloCamera(ArloChildDevice):
             return True
         if cap in (AUDIO_DETECTED_KEY,):
             if self.model_id.startswith(
-                ('arloq', 'VMC4030', 'VMC4040', 'VMC5040', 'ABC1000', 'FB1001')
-            ):
+                ('VMC4030', 'VMC4040', 'VMC5040', 'ABC1000', 'FB1001')):
+                return True
+            if self.device_type.startswith('arloq'):
                 return True
         if cap in (SIREN_STATE_KEY,):
             if self.model_id.startswith(('VMC4040', 'VMC5040', 'FB1001')):


### PR DESCRIPTION
The ported code was using the model_id not device_id.