### PR TITLE
Handle duplicate named connection IDs

### DIFF
--- a/custom_components/aarlo/pyaarlo/base.py
+++ b/custom_components/aarlo/pyaarlo/base.py
@@ -250,8 +250,11 @@ class ArloBase(ArloDevice):
             resp = self._arlo.be.notify(base=self, body={"action": "get", "resource": "modes",
                                                          "publishResponse": False},
                                         wait_for="event")
-            props = resp.get('properties', {})
-            self._parse_modes(props.get('modes', []))
+            if resp is not None:
+                props = resp.get('properties', {})
+                self._parse_modes(props.get('modes', []))
+            else:
+                self._arlo.error("unable to read mode, try forcing v2");
         else:
             modes = self._arlo.be.get(DEFINITIONS_PATH + "?uniqueIds={}".format(self.unique_id))
             modes = modes.get(self.unique_id, {})

--- a/custom_components/aarlo/pyaarlo/camera.py
+++ b/custom_components/aarlo/pyaarlo/camera.py
@@ -8,7 +8,7 @@ from .constant import (
     ACTIVITY_STATE_KEY, AIR_QUALITY_KEY, AUDIO_ANALYTICS_KEY,
     AUDIO_DETECTED_KEY, AUDIO_POSITION_KEY, AUDIO_TRACK_KEY, BATTERY_KEY,
     BRIGHTNESS_KEY, CAMERA_MEDIA_DELAY, CAPTURED_TODAY_KEY, CRY_DETECTION_KEY,
-    FLIP_KEY, FLOODLIGHT_BRIGHTNESS1_KEY,
+    CONNECTION_KEY, FLIP_KEY, FLOODLIGHT_BRIGHTNESS1_KEY,
     FLOODLIGHT_BRIGHTNESS2_KEY, FLOODLIGHT_KEY, HUMIDITY_KEY,
     IDLE_SNAPSHOT_PATH, LAMP_STATE_KEY, LAST_CAPTURE_KEY, LAST_IMAGE_DATA_KEY,
     LAST_IMAGE_KEY, LAST_IMAGE_SRC_KEY, LIGHT_BRIGHTNESS_KEY, LIGHT_MODE_KEY,
@@ -1175,4 +1175,10 @@ class ArloCamera(ArloChildDevice):
         if cap in (FLOODLIGHT_KEY,):
             if self.model_id.startswith('FB1001'):
                 return True
+        if cap in (CONNECTION_KEY,):
+            # These devices are their own base stations so don't re-add connection key.
+            if self.model_id.startswith(('ABC1000', 'FB1001A')):
+                return False;
+            if self.device_type in ('arloq', 'arloqs'):
+                return False
         return super().has_capability(cap)

--- a/custom_components/aarlo/pyaarlo/doorbell.py
+++ b/custom_components/aarlo/pyaarlo/doorbell.py
@@ -59,6 +59,10 @@ class ArloDoorBell(ArloChildDevice):
             # video doorbell provides these as a camera type
             if not self.model_id.startswith('AVD1001'):
                 return True
+        if cap in (CONNECTION_KEY,):
+            # If video door bell is its own base station then don't provide connectivity here.
+            if self.model_id.startswith('AVD1001') and self.parent_id == self.device_id:
+                return False
         return super().has_capability(cap)
 
     def silent_mode(self, active, block_call):


### PR DESCRIPTION

Where a device is its own base stations - an ArloBaby or Arloq - the code will generate 2 connection binary sensors with the same IDs.

This code won't generate those sensors.
