### PR TITLE
Handle modes read fail.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,5 @@
 aarlo/pyaarlo
+0.7.0.4: Handle broken modes fetch.
 0.7.0.3: Handle broken library fetch.
 0.7.0.2: Made mode refresh optional.
 0.7.0: Added PUSH support for authentication.

--- a/custom_components/aarlo/__init__.py
+++ b/custom_components/aarlo/__init__.py
@@ -28,7 +28,7 @@ from requests.exceptions import ConnectTimeout, HTTPError
 
 from .pyaarlo.constant import DEFAULT_AUTH_HOST, DEFAULT_HOST, SIREN_STATE_KEY
 
-__version__ = "0.7.0.2"
+__version__ = "0.7.0.4"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -420,6 +420,7 @@ def login(hass, conf):
             )
 
             if arlo.is_connected:
+                _LOGGER.debug(f"login succeeded, attempt={attempt}")
                 return arlo
 
             if attempt == 1:

--- a/custom_components/aarlo/pyaarlo/__init__.py
+++ b/custom_components/aarlo/pyaarlo/__init__.py
@@ -31,7 +31,7 @@ from .util import time_to_arlotime
 
 _LOGGER = logging.getLogger("pyaarlo")
 
-__version__ = "0.7.0.2"
+__version__ = "0.7.0.4"
 
 
 class PyArlo(object):

--- a/custom_components/aarlo/pyaarlo/base.py
+++ b/custom_components/aarlo/pyaarlo/base.py
@@ -335,9 +335,12 @@ class ArloBase(ArloDevice):
             modes = self._arlo.be.get(
                 DEFINITIONS_PATH + "?uniqueIds={}".format(self.unique_id)
             )
-            modes = modes.get(self.unique_id, {})
-            self._parse_modes(modes.get("modes", []))
-            self._parse_schedules(modes.get("schedules", []))
+            if modes is not None:
+                modes = modes.get(self.unique_id, {})
+                self._parse_modes(modes.get("modes", []))
+                self._parse_schedules(modes.get("schedules", []))
+            else:
+                self._arlo.error("failed to read modes (v2)")
 
     @property
     def schedule(self):


### PR DESCRIPTION
The `uniqueIds` call to read modes can fail. This fix handles the fail.