### PR TITLE
Smart user agent

### DIFF
--- a/custom_components/aarlo/__init__.py
+++ b/custom_components/aarlo/__init__.py
@@ -92,7 +92,7 @@ STR_TIMEOUT = timedelta(seconds=0)
 NO_MEDIA_UP = False
 MEDIA_RETRY = None
 SNAPSHOT_CHECKS = None
-USER_AGENT = "apple"
+USER_AGENT = "arlo"
 MODE_API = "auto"
 DEVICE_REFRESH = 0
 MODE_REFRESH = 0

--- a/custom_components/aarlo/camera.py
+++ b/custom_components/aarlo/camera.py
@@ -526,14 +526,19 @@ class ArloCam(Camera):
         return COMPONENT_BRAND
 
     async def stream_source(self):
-        """Return the source of the stream."""
-        if is_homekit():
-            return self._camera.get_stream()
-        else:
-            return await self.hass.async_add_executor_job(self._camera.get_stream)
+        """Return the source of the stream.
 
-    async def async_stream_source(self):
-        return await self.hass.async_add_executor_job(self._camera.get_stream)
+        Note, this is only used by `camera/stream` websocket so we force the `User-Agent`
+        to the original Arlo one. This means we get a `rtsps` stream back which the stream
+        component can handle.
+        """
+        if is_homekit():
+            return self._camera.get_stream(user_agent="arlo")
+        else:
+            return await self.hass.async_add_executor_job(self._camera.get_stream,user_agent="arlo")
+
+    async def async_stream_source(self, user_agent=None):
+        return await self.hass.async_add_executor_job(self._camera.get_stream, user_agent)
 
     def camera_image(self):
         """Return a still image response from the camera."""
@@ -662,11 +667,13 @@ class ArloCam(Camera):
         return await self.hass.async_add_executor_job(self.siren_off)
 
     def start_recording(self, duration=30):
-        active = self._attach_hidden_stream(duration + 10)
-        if active:
-            source = self._camera.start_recording_stream()
-            self._camera.start_recording(duration=(duration))
-            return source
+        source = self._camera.start_recording_stream(user_agent="arlo")
+        if source:
+            active = self._attach_hidden_stream(duration + 10)
+            if active:
+                # source = self._camera.start_recording_stream()
+                self._camera.start_recording(duration=duration)
+                return source
         _LOGGER.warning("failed to start recording for {}".format(self._camera.name))
         return None
 
@@ -756,7 +763,9 @@ async def websocket_stream_url(hass, connection, msg):
         camera = get_entity_from_domain(hass, DOMAIN, msg["entity_id"])
         _LOGGER.debug("stream_url for " + str(camera.unique_id))
 
-        stream = await camera.async_stream_source()
+        # start stream and force user agent to linux, this will return a `mpeg dash`
+        # stream we can use directly from the Lovelace card
+        stream = await camera.async_stream_source(user_agent='linux')
         connection.send_message(
             websocket_api.result_message(msg["id"], {"url": stream})
         )

--- a/custom_components/aarlo/pyaarlo/__init__.py
+++ b/custom_components/aarlo/pyaarlo/__init__.py
@@ -111,7 +111,7 @@ class PyArlo(object):
     * **no_media_upload** - Force a media upload after camera activity.
       Normally not needed but some systems fail to push media uploads. Default 'False'.
     * **user_agent** - Set what 'user-agent' string is passed in request headers. It affects what video stream type is
-      returned. Default is `apple`.
+      returned. Default is `arlo`.
     * **mode_api** - Which api to use to set the base station modes. Default is `auto` which choose an API
       based on camera model. Can also be `v1` and `v2`.
     * **http_connections** - HTTP connection pool size. Default is `20`, set to `None` to default provided

--- a/custom_components/aarlo/pyaarlo/backend.py
+++ b/custom_components/aarlo/pyaarlo/backend.py
@@ -596,28 +596,8 @@ class ArloBackEnd(object):
 
     def _login(self):
 
-        # set agent before starting
-        if self._arlo.cfg.user_agent == "apple":
-            self._user_agent = (
-                "Mozilla/5.0 (iPhone; CPU iPhone OS 11_1_2 like Mac OS X) "
-                "AppleWebKit/604.3.5 (KHTML, like Gecko) Mobile/15B202 NETGEAR/v1 "
-                "(iOS Vuezone)"
-            )
-        elif self._arlo.cfg.user_agent == "new":
-            self._user_agent = (
-                "Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_3 like Mac OS X) "
-                "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Mobile/15E148 Safari/604.1"
-            )
-        elif self._arlo.cfg.user_agent == "mac":
-            self._user_agent = (
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) "
-                "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1.2 Safari/605.1.15"
-            )
-        else:
-            self._user_agent = (
-                "Mozilla/5.0 (X11; Linux x86_64) "
-                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36"
-            )
+        # pickup user configured user agent
+        self._user_agent = self.user_agent(self._arlo.cfg.user_agent)
 
         # set up session
         self._session = requests.Session()
@@ -874,6 +854,45 @@ class ArloBackEnd(object):
 
     def devices(self):
         return self.get(DEVICES_PATH + "?t={}".format(time_to_arlotime()))
+
+    def user_agent(self, agent):
+        """ Map `agent` to a real user agent.
+
+        User provides a default user agent they want for most interactions but it can be overridden
+        for stream operations.
+        """
+        self._arlo.debug(f"looking for user_agent {agent}")
+        if agent.lower() == "arlo":
+            return (
+                "Mozilla/5.0 (iPhone; CPU iPhone OS 11_1_2 like Mac OS X) "
+                "AppleWebKit/604.3.5 (KHTML, like Gecko) Mobile/15B202 NETGEAR/v1 "
+                "(iOS Vuezone)"
+            )
+        elif agent.lower() == "iphone":
+            return (
+                "Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_3 like Mac OS X) "
+                "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Mobile/15E148 Safari/604.1"
+            )
+        elif agent.lower() == "ipad":
+            return (
+                "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) "
+                "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 Mobile/15E148 Safari/604.1"
+            )
+        elif agent.lower() == "mac":
+            return (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) "
+                "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1.2 Safari/605.1.15"
+            )
+        elif agent.lower() == "firefox":
+            return (
+                "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:85.0) "
+                "Gecko/20100101 Firefox/85.0"
+            )
+        else:
+            return (
+                "Mozilla/5.0 (X11; Linux x86_64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36"
+            )
 
     def ev_inject(self, response):
         self._ev_dispatcher(response)

--- a/custom_components/aarlo/pyaarlo/camera.py
+++ b/custom_components/aarlo/pyaarlo/camera.py
@@ -259,7 +259,7 @@ class ArloCamera(ArloChildDevice):
             },
         )
 
-    def _start_stream(self, starting_for):
+    def _start_stream(self, starting_for, user_agent=None):
         with self._lock:
             # Already streaming. Update sub-activity as needed.
             if self.has_any_local_users:
@@ -286,8 +286,15 @@ class ArloCamera(ArloChildDevice):
             "to": self.parent_id,
             "transId": self._arlo.be.gen_trans_id(),
         }
+
+        headers = {
+            "xcloudId": self.xcloud_id
+        }
+        if user_agent is not None:
+            headers["User-Agent"] = self._arlo.be.user_agent(user_agent)
+
         self._stream_url = self._arlo.be.post(
-            STREAM_START_PATH, body, headers={"xcloudId": self.xcloud_id}
+            STREAM_START_PATH, body, headers=headers
         )
         if self._stream_url is not None:
             self._stream_url = self._stream_url["url"].replace("rtsp://", "rtsps://")
@@ -863,29 +870,29 @@ class ArloCamera(ArloChildDevice):
             return "recently active"
         return super().state
 
-    def get_stream(self):
+    def get_stream(self, user_agent=None):
         """Start a stream and return the URL for it.
 
         Code does nothing with the url, it's up to you to pass the url to something.
 
         The stream will stop if nothing connects to it within 30 seconds.
         """
-        return self._start_stream("streaming")
+        return self._start_stream("streaming", user_agent)
 
-    def start_stream(self):
+    def start_stream(self, user_agent=None):
         """Start a stream and return the URL for it.
 
         Code does nothing with the url, it's up to you to pass the url to something.
 
         The stream will stop if nothing connects to it within 30 seconds.
         """
-        return self._start_stream("streaming")
+        return self._start_stream("streaming", user_agent)
 
-    def start_snapshot_stream(self):
-        return self._start_stream("snapshot")
+    def start_snapshot_stream(self, user_agent=None):
+        return self._start_stream("snapshot", user_agent)
 
-    def start_recording_stream(self):
-        return self._start_stream("recording")
+    def start_recording_stream(self, user_agent=None):
+        return self._start_stream("recording", user_agent)
 
     def stop_stream(self):
         self._stop_stream("streaming")

--- a/custom_components/aarlo/pyaarlo/cfg.py
+++ b/custom_components/aarlo/pyaarlo/cfg.py
@@ -105,7 +105,7 @@ class ArloCfg(object):
 
     @property
     def user_agent(self):
-        return self._kw.get("user_agent", "apple")
+        return self._kw.get("user_agent", "arlo")
 
     @property
     def mode_api(self):

--- a/install
+++ b/install
@@ -35,7 +35,7 @@ fi
 
 ${ECHO} mkdir -p "${DEST}/custom_components"
 if [[ -n $(command -v fd) ]]; then
-	fd -e py . custom_components --exec ${ECHO} cp -vf --parents {} "${DEST}" ;
+	fd -e py . -e json -e yaml custom_components --exec ${ECHO} cp -vf --parents {} "${DEST}" ;
 else
 	${ECHO} cp -afv custom_components/aarlo "${DEST}/custom_components"
 fi


### PR DESCRIPTION
The code will now send different user agents depending on who will be handling the stream.

`camera/stream`; this gets set to `arlo` so rtsps streams are returned
`aarlo_stream_url`; this is forced to `linux` to we get an mpeg-dash stream

All other stream interactions use the user's configured user agent type.