### PR TITLE
Stop polling

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,5 @@
 aarlo/pyaarlo
+0.7.1b7: Stop HA polling us.
 0.7.1b6: Add new event handling
         Allow custimisable disarmed mode
 0.7.1b5: Don't rely on camera reporting back idle status

--- a/custom_components/aarlo/alarm_control_panel.py
+++ b/custom_components/aarlo/alarm_control_panel.py
@@ -149,7 +149,7 @@ async def async_setup_platform(hass, config, async_add_entities, _discovery_info
         if base_station.has_capability(SIREN_STATE_KEY):
             base_stations_with_sirens = True
 
-    async_add_entities(base_stations, True)
+    async_add_entities(base_stations)
 
     # Component services
     def service_callback(call):

--- a/custom_components/aarlo/alarm_control_panel.py
+++ b/custom_components/aarlo/alarm_control_panel.py
@@ -237,6 +237,10 @@ class ArloBaseStation(AlarmControlPanelEntity):
         self._base.add_attr_callback(MODE_KEY, update_state)
 
     @property
+    def should_poll(self):
+        return False
+
+    @property
     def state(self):
         """Return the state of the device."""
         if self._trigger_till is not None:

--- a/custom_components/aarlo/binary_sensor.py
+++ b/custom_components/aarlo/binary_sensor.py
@@ -104,6 +104,10 @@ class ArloBinarySensor(BinarySensorEntity):
             self._device.add_attr_callback(other_attr, update_state)
 
     @property
+    def should_poll(self):
+        return False
+
+    @property
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id

--- a/custom_components/aarlo/binary_sensor.py
+++ b/custom_components/aarlo/binary_sensor.py
@@ -67,7 +67,7 @@ async def async_setup_platform(hass, config, async_add_entities, _discovery_info
             if light.has_capability(SENSOR_TYPES.get(sensor_type)[2]):
                 sensors.append(ArloBinarySensor(light, sensor_type))
 
-    async_add_entities(sensors, True)
+    async_add_entities(sensors)
 
 
 class ArloBinarySensor(BinarySensorEntity):

--- a/custom_components/aarlo/light.py
+++ b/custom_components/aarlo/light.py
@@ -67,7 +67,7 @@ async def async_setup_platform(hass, _config, async_add_entities, _discovery_inf
         if camera.has_capability(SPOTLIGHT_KEY):
             lights.append(ArloSpotlight(camera))
 
-    async_add_entities(lights, True)
+    async_add_entities(lights)
 
 
 class ArloLight(LightEntity):

--- a/custom_components/aarlo/light.py
+++ b/custom_components/aarlo/light.py
@@ -100,6 +100,10 @@ class ArloLight(LightEntity):
         self._light.add_attr_callback(BRIGHTNESS_KEY, update_state)
 
     @property
+    def should_poll(self):
+        return False
+
+    @property
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id

--- a/custom_components/aarlo/media_player.py
+++ b/custom_components/aarlo/media_player.py
@@ -131,6 +131,10 @@ class ArloMediaPlayer(MediaPlayerEntity, ABC):
         return self._name
 
     @property
+    def should_poll(self):
+        return False
+
+    @property
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id

--- a/custom_components/aarlo/media_player.py
+++ b/custom_components/aarlo/media_player.py
@@ -66,7 +66,7 @@ async def async_setup_platform(hass, _config, async_add_entities, _discovery_inf
             name = "{0}".format(camera.name)
             players.append(ArloMediaPlayer(name, camera))
 
-    async_add_entities(players, True)
+    async_add_entities(players)
 
 
 class ArloMediaPlayer(MediaPlayerEntity, ABC):

--- a/custom_components/aarlo/pyaarlo/camera.py
+++ b/custom_components/aarlo/pyaarlo/camera.py
@@ -281,7 +281,7 @@ class ArloCamera(ArloChildDevice):
                 "publishResponse": True,
                 "resource": self.resource_id,
             },
-            wait_for="response"
+            wait_for="response",
         )
         if response is not None:
             self._mark_as_idle()
@@ -428,9 +428,7 @@ class ArloCamera(ArloChildDevice):
 
         # Non subscription...
         if event.get("action", "") == "lastImageSnapshotAvailable":
-            value = event.get("properties", {}).get(
-                "presignedLastImageUrl", None
-            )
+            value = event.get("properties", {}).get("presignedLastImageUrl", None)
             if value is not None:
                 self._arlo.debug("{} -> snapshot3 ready".format(self.name))
                 self._save(SNAPSHOT_KEY, value)

--- a/custom_components/aarlo/sensor.py
+++ b/custom_components/aarlo/sensor.py
@@ -124,6 +124,10 @@ class ArloSensor(Entity):
             self._device.add_attr_callback(self._attr, update_state)
 
     @property
+    def should_poll(self):
+        return False
+
+    @property
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id

--- a/custom_components/aarlo/sensor.py
+++ b/custom_components/aarlo/sensor.py
@@ -80,7 +80,7 @@ async def async_setup_platform(hass, config, async_add_entities, _discovery_info
                 if light.has_capability(SENSOR_TYPES[sensor_type][3]):
                     sensors.append(ArloSensor(arlo, light, sensor_type))
 
-    async_add_entities(sensors, True)
+    async_add_entities(sensors)
 
 
 class ArloSensor(Entity):

--- a/custom_components/aarlo/switch.py
+++ b/custom_components/aarlo/switch.py
@@ -117,6 +117,10 @@ class AarloSwitch(SwitchEntity):
         return self._icon
 
     @property
+    def should_poll(self):
+        return False
+
+    @property
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id
@@ -203,7 +207,6 @@ class AarloSirenBaseSwitch(AarloSwitch):
 
     def do_off(self):
         _LOGGER.debug("implement do off")
-
 
 class AarloSirenSwitch(AarloSirenBaseSwitch):
     """Representation of an Aarlo switch."""

--- a/custom_components/aarlo/switch.py
+++ b/custom_components/aarlo/switch.py
@@ -97,7 +97,7 @@ async def async_setup_platform(hass, config, async_add_entities, _discovery_info
                 devices.append(AarloSilentModeChimeSwitch(doorbell))
                 devices.append(AarloSilentModeCallSwitch(doorbell))
 
-    async_add_entities(devices, True)
+    async_add_entities(devices)
 
 
 class AarloSwitch(SwitchEntity):
@@ -207,6 +207,7 @@ class AarloSirenBaseSwitch(AarloSwitch):
 
     def do_off(self):
         _LOGGER.debug("implement do off")
+
 
 class AarloSirenSwitch(AarloSirenBaseSwitch):
     """Representation of an Aarlo switch."""


### PR DESCRIPTION

Long standing inefficiency. Stop HA from polling every Arlo device every 30 seconds.

We're event driven so no polling necessary.

