### PR TITLE
Remove unicode characters from entity IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,13 @@ Entity ID naming follows this pattern
 For example, a camera called "Front Door" will have an entity id of
 `camera.aarlo_front_door`.
 
+For full compabilty `aarlo` will decode unicode characters. This means a 
+camera called `Haustür` will be called `component-type.aarlo_haustur`.
+
+If you do not want this behaviour - and be warned, this may cause problems 
+using certain HA services - add `no_unicode_squash: True` to your configuration.
+
+
 <a name="other-saving-media"></a>
 ### Saving Media
 If you use the `save_media_to` parameter to specify a file naming scheme

--- a/changelog
+++ b/changelog
@@ -1,5 +1,6 @@
 aarlo/pyaarlo
 0.7.1b7: Stop HA polling us.
+        Remove unicode characters from entity ids
 0.7.1b6: Add new event handling
         Allow custimisable disarmed mode
 0.7.1b5: Don't rely on camera reporting back idle status

--- a/custom_components/aarlo/__init__.py
+++ b/custom_components/aarlo/__init__.py
@@ -78,6 +78,7 @@ CONF_STREAM_SNAPSHOT_STOP = "stream_snapshot_stop"
 CONF_SAVE_UPDATES_TO = "save_updates_to"
 CONF_USER_STREAM_DELAY = "user_stream_delay"
 CONF_SAVE_MEDIA_TO = "save_media_to"
+CONF_NO_UNICODE_SQUASH = "no_unicode_squash"
 
 SCAN_INTERVAL = timedelta(seconds=60)
 PACKET_DUMP = False
@@ -115,6 +116,7 @@ STREAM_SNAPSHOT_STOP = 0
 SAVE_UPDATES_TO = ""
 USER_STREAM_DELAY = 1
 SAVE_MEDIA_TO = ""
+NO_UNICODE_SQUASH = False
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -190,6 +192,7 @@ CONFIG_SCHEMA = vol.Schema(
                     CONF_USER_STREAM_DELAY, default=USER_STREAM_DELAY
                 ): cv.positive_int,
                 vol.Optional(CONF_SAVE_MEDIA_TO, default=SAVE_MEDIA_TO): cv.string,
+                vol.Optional(CONF_NO_UNICODE_SQUASH, default=NO_UNICODE_SQUASH): cv.boolean,
             }
         ),
     },
@@ -365,6 +368,7 @@ def login(hass, conf):
     save_updates_to = conf.get(CONF_SAVE_UPDATES_TO)
     save_media_to = conf.get(CONF_SAVE_MEDIA_TO)
     user_stream_delay = conf.get(CONF_USER_STREAM_DELAY)
+    no_unicode_squash = conf.get(CONF_NO_UNICODE_SQUASH)
 
     # Fix up config
     if conf_dir == "":
@@ -417,6 +421,7 @@ def login(hass, conf):
                 stream_snapshot_stop=stream_snapshot_stop,
                 save_updates_to=save_updates_to,
                 user_stream_delay=user_stream_delay,
+                no_unicode_squash=no_unicode_squash,
                 save_media_to=save_media_to,
                 wait_for_initial_setup=False,
                 verbose_debug=verbose_debug,

--- a/custom_components/aarlo/manifest.json
+++ b/custom_components/aarlo/manifest.json
@@ -5,6 +5,6 @@
   "issue_tracker": "https://github.com/twrecked/hass-aarlo/issues",
   "dependencies": ["ffmpeg"],
   "codeowners": ["@twrecked"],
-  "requirements": [],
-  "version": "0.7.1b6"
+  "requirements": ["unidecode"],
+  "version": "0.7.1b7"
 }

--- a/custom_components/aarlo/pyaarlo/cfg.py
+++ b/custom_components/aarlo/pyaarlo/cfg.py
@@ -236,3 +236,7 @@ class ArloCfg(object):
     @property
     def save_media_to(self):
         return self._kw.get("save_media_to", "")
+
+    @property
+    def no_unicode_squash(self):
+        return self._kw.get("no_unicode_squash", False)

--- a/custom_components/aarlo/pyaarlo/device.py
+++ b/custom_components/aarlo/pyaarlo/device.py
@@ -1,4 +1,5 @@
 import threading
+from unidecode import unidecode
 
 from .constant import (
     BATTERY_KEY,
@@ -105,8 +106,10 @@ class ArloDevice(object):
     def entity_id(self):
         if self._arlo.cfg.serial_ids:
             return self.device_id
-        else:
+        elif self._arlo.cfg.no_unicode_squash:
             return self.name.lower().replace(" ", "_")
+        else:
+            return unidecode(self.name.lower().replace(" ", "_"))
 
     @property
     def name(self):


### PR DESCRIPTION
It seems some services - camera.record for example - don't like unicode characters in the entity id.