### PR TITLE
Added port to IMAP host

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,9 @@ with your Home Assistant account and make sure the camera names are correct.
 You can change the brightness on the light but not while it's turned on. You need to turn
 it off and back on again for the change to take. This is how the web interface does it.
 
+You might see `CloudFlareChallengeError`s. There is a strange interaction
+between Python's networking and the Cloud Flare servers. I'm working on it.
+
 <a name="other-debugging"></a>
 ### Debugging
 If you run into problems there please provide the following in the bug report to help
@@ -955,7 +958,16 @@ aarlo:
 
 It's working well with my gmail account, see
 [here](https://support.google.com/mail/answer/185833?hl=en) for help setting up single app
-passwords.
+passwords. If needed, you can specify a port by appending it to the host.
+
+```yaml
+aarlo:
+  tfa_source: imap
+  tfa_type: email
+  tfa_host: imap.host.com:1234
+  tfa_username: your-user-name
+  tfa_password: your-imap-password
+```
 
 <a name="2fa-push"></a>
 #### PUSH

--- a/custom_components/aarlo/pyaarlo/base.py
+++ b/custom_components/aarlo/pyaarlo/base.py
@@ -485,7 +485,12 @@ class ArloBase(ArloDevice):
             if (
                 self.is_own_parent
                 and self.model_id.startswith(
-                    (MODEL_WIREFREE_VIDEO_DOORBELL, MODEL_ESSENTIAL, MODEL_PRO_3_FLOODLIGHT, MODEL_PRO_4)
+                    (
+                        MODEL_WIREFREE_VIDEO_DOORBELL,
+                        MODEL_ESSENTIAL,
+                        MODEL_PRO_3_FLOODLIGHT,
+                        MODEL_PRO_4,
+                    )
                 )
                 and not self.is_corded
             ):

--- a/custom_components/aarlo/pyaarlo/cfg.py
+++ b/custom_components/aarlo/pyaarlo/cfg.py
@@ -169,7 +169,16 @@ class ArloCfg(object):
 
     @property
     def tfa_host(self):
-        return self._kw.get("tfa_host", TFA_DEFAULT_HOST)
+        h = self._kw.get("tfa_host", TFA_DEFAULT_HOST).split(":")
+        return h[0]
+
+    @property
+    def tfa_port(self):
+        h = self._kw.get("tfa_host", TFA_DEFAULT_HOST).split(":")
+        if len(h) == 1:
+            return 993
+        else:
+            return h[1]
 
     @property
     def tfa_username(self):

--- a/custom_components/aarlo/pyaarlo/tfa.py
+++ b/custom_components/aarlo/pyaarlo/tfa.py
@@ -47,7 +47,9 @@ class Arlo2FAImap:
             self.stop()
 
         try:
-            self._imap = imaplib.IMAP4_SSL(self._arlo.cfg.tfa_host)
+            self._imap = imaplib.IMAP4_SSL(
+                self._arlo.cfg.tfa_host, port=self._arlo.cfg.tfa_port
+            )
             res, status = self._imap.login(
                 self._arlo.cfg.tfa_username, self._arlo.cfg.tfa_password
             )


### PR DESCRIPTION
You can now specify an IMAP port as part of the `tfa_host`.
