### PR TITLE
Support sse and mqtt backends.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,5 @@
 aarlo/pyaarlo
+0.7.2b6: Allow sse backend to be used.
 0.7.2b5: Fix warning message about device attributes.
 0.7.2b4: Read properties for devices in device refresh
 0.7.2b2: Read properties for devices in device refresh.

--- a/custom_components.json
+++ b/custom_components.json
@@ -1,6 +1,6 @@
 {
     "aarlo": {
-        "version": "0.7.2b5",
+        "version": "0.7.2b6",
         "local_location": "/custom_components/aarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/custom_components/aarlo/__init__.py",
         "visit_repo": "https://github.com/twrecked/hass-aarlo",
@@ -18,7 +18,7 @@
         ]
     },
     "pyaarlo": {
-        "version": "0.7.2b5",
+        "version": "0.7.2b6",
         "local_location": "/custom_components/aarlo/pyaarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/custom_components/aarlo/pyaarlo/__init__.py",
         "visit_repo": "https://github.com/twrecked/hass-aarlo",

--- a/custom_components/aarlo/__init__.py
+++ b/custom_components/aarlo/__init__.py
@@ -28,7 +28,7 @@ from requests.exceptions import ConnectTimeout, HTTPError
 
 from .pyaarlo.constant import DEFAULT_AUTH_HOST, DEFAULT_HOST, SIREN_STATE_KEY
 
-__version__ = "0.7.2b5"
+__version__ = "0.7.2b6"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -80,6 +80,7 @@ CONF_USER_STREAM_DELAY = "user_stream_delay"
 CONF_SAVE_MEDIA_TO = "save_media_to"
 CONF_NO_UNICODE_SQUASH = "no_unicode_squash"
 CONF_SAVE_SESSION = "save_session"
+CONF_BACKEND = "backend"
 
 SCAN_INTERVAL = timedelta(seconds=60)
 PACKET_DUMP = False
@@ -119,6 +120,7 @@ USER_STREAM_DELAY = 1
 SAVE_MEDIA_TO = ""
 NO_UNICODE_SQUASH = True
 SAVE_SESSION = True
+DEFAULT_BACKEND = "mqtt"
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -198,6 +200,7 @@ CONFIG_SCHEMA = vol.Schema(
                     CONF_NO_UNICODE_SQUASH, default=NO_UNICODE_SQUASH
                 ): cv.boolean,
                 vol.Optional(CONF_SAVE_SESSION, default=SAVE_SESSION): cv.boolean,
+                vol.Optional(CONF_BACKEND, default=DEFAULT_BACKEND): cv.string,
             }
         ),
     },
@@ -375,6 +378,7 @@ def login(hass, conf):
     user_stream_delay = conf.get(CONF_USER_STREAM_DELAY)
     no_unicode_squash = conf.get(CONF_NO_UNICODE_SQUASH)
     save_session = conf.get(CONF_SAVE_SESSION)
+    backend = conf.get(CONF_BACKEND)
 
     # Fix up config
     if conf_dir == "":
@@ -430,6 +434,7 @@ def login(hass, conf):
                 no_unicode_squash=no_unicode_squash,
                 save_media_to=save_media_to,
                 save_session=save_session,
+                backend=backend,
                 wait_for_initial_setup=False,
                 verbose_debug=verbose_debug,
             )

--- a/custom_components/aarlo/manifest.json
+++ b/custom_components/aarlo/manifest.json
@@ -6,6 +6,6 @@
   "dependencies": ["ffmpeg"],
   "codeowners": ["@twrecked"],
   "requirements": ["unidecode","cloudscraper>=1.2.58", "paho-mqtt"],
-  "version": "0.7.2b5",
+  "version": "0.7.2b6",
   "iot_class": "cloud_push"
 }

--- a/custom_components/aarlo/pyaarlo/__init__.py
+++ b/custom_components/aarlo/pyaarlo/__init__.py
@@ -40,7 +40,7 @@ from .util import time_to_arlotime
 
 _LOGGER = logging.getLogger("pyaarlo")
 
-__version__ = "0.7.2b5"
+__version__ = "0.7.2b6"
 
 
 class PyArlo(object):

--- a/custom_components/aarlo/pyaarlo/backend.py
+++ b/custom_components/aarlo/pyaarlo/backend.py
@@ -1,13 +1,13 @@
 import json
 import pickle
 import pprint
+import random
 import re
 import ssl
 import threading
 import time
 import traceback
 import uuid
-from random import randint
 
 import cloudscraper
 import paho.mqtt.client as mqtt
@@ -29,12 +29,14 @@ from .constant import (
     ORIGIN_HOST,
     REFERER_HOST,
     SESSION_PATH,
+    SUBSCRIBE_PATH,
     TFA_CONSOLE_SOURCE,
     TFA_IMAP_SOURCE,
     TFA_PUSH_SOURCE,
     TFA_REST_API_SOURCE,
     TRANSID_PREFIX,
 )
+from .sseclient import SSEClient
 from .tfa import Arlo2FAConsole, Arlo2FAImap, Arlo2FARestAPI
 from .util import days_until, now_strftime, time_to_arlotime, to_b64
 
@@ -48,6 +50,7 @@ class ArloBackEnd(object):
         self._req_lock = threading.Lock()
 
         self._dump_file = self._arlo.cfg.dump_file
+        self._use_mqtt = self._arlo.cfg.use_mqtt
 
         self._requests = {}
         self._callbacks = {}
@@ -55,10 +58,11 @@ class ArloBackEnd(object):
 
         self._load_session()
 
-        self._ev_client = None
-        self._ev_thread = None
-        self._ev_connected = False
-        self._stopThread = False
+        # event thread stuff
+        self._event_thread = None
+        self._event_client = None
+        self._event_connected = False
+        self._stop_thread = False
 
         # login
         self._session = None
@@ -189,11 +193,7 @@ class ArloBackEnd(object):
     def gen_trans_id(self, trans_type=TRANSID_PREFIX):
         return trans_type + "!" + str(uuid.uuid4())
 
-    def _ev_reconnected(self):
-        self._arlo.debug("Fetching device list after ev-reconnect")
-        self.devices()
-
-    def _ev_dispatcher(self, response):
+    def _event_dispatcher(self, response):
 
         # get message type(s) and id(s)
         responses = []
@@ -300,7 +300,7 @@ class ArloBackEnd(object):
             for cb in cbs:
                 self._arlo.bg.run(cb, resource=resource, event=response)
 
-    def _ev_response(self, response):
+    def _event_handle_response(self, response):
 
         # Debugging.
         if self._dump_file is not None:
@@ -311,13 +311,8 @@ class ArloBackEnd(object):
                 )
         self._arlo.vdebug("packet-in=\n{}".format(pprint.pformat(response, indent=2)))
 
-        # Logged out? MQTT will log back in until stopped.
-        if response.get("action") == "logout":
-            self._arlo.warning("logged out? did you log in from elsewhere?")
-            return
-
         # Run the dispatcher to set internal state and run callbacks.
-        self._ev_dispatcher(response)
+        self._event_dispatcher(response)
 
         # is there a notify/post waiting for this response? If so, signal to waiting entity.
         tid = response.get("transId", None)
@@ -354,10 +349,46 @@ class ArloBackEnd(object):
                             self._requests[request] = response
                             self._lock.notify_all()
 
-    def mqtt_subscribe(self):
+    def _event_stop_loop(self):
+        self._stop_thread = True
+
+    def _event_main(self):
+        self._arlo.debug("re-logging in")
+
+        while not self._stop_thread:
+
+            # say we're starting
+            if self._dump_file is not None:
+                with open(self._dump_file, "a") as dump:
+                    time_stamp = now_strftime("%Y-%m-%d %H:%M:%S.%f")
+                    dump.write("{}: {}\n".format(time_stamp, "event_thread start"))
+
+            # login again if not first iteration, this will also create a new session
+            while not self._logged_in:
+                with self._lock:
+                    self._lock.wait(5)
+                self._arlo.debug("re-logging in")
+                self._logged_in = self._login()
+
+            if self._use_mqtt:
+                self._mqtt_main()
+            else:
+                self._sse_main()
+
+            # clear down and signal out
+            with self._lock:
+                self._client_connected = False
+                self._requests = {}
+                self._lock.notify_all()
+
+            # restart login...
+            self._event_client = None
+            self._logged_in = False
+
+    def _mqtt_subscribe(self):
         # Make sure we are listening to library events and individual base
         # station events. This seems sufficient for now.
-        self._ev_client.subscribe(
+        self._event_client.subscribe(
             [
                 (f"u/{self._user_id}/in/userSession/connect", 0),
                 (f"u/{self._user_id}/in/userSession/disconnect", 0),
@@ -372,102 +403,166 @@ class ArloBackEnd(object):
             for topic in device.get("allowedMqttTopics", []):
                 topics.append((topic, 0))
         self._arlo.debug("topcs=\n{}".format(pprint.pformat(topics)))
-        self._ev_client.subscribe(topics)
+        self._event_client.subscribe(topics)
 
-    def mqtt_on_connect(self, _client, _userdata, _flags, rc):
+    def _mqtt_on_connect(self, _client, _userdata, _flags, rc):
         # Subscribing in on_connect() means that if we lose the connection and
         # reconnect then subscriptions will be renewed.
         self._arlo.debug(f"mqtt: connected={str(rc)}")
-        self.mqtt_subscribe()
+        self._mqtt_subscribe()
         with self._lock:
-            self._ev_connected = True
+            self._event_connected = True
             self._lock.notify_all()
 
-    def mqtt_on_log(self, _client, _userdata, _level, msg):
+    def _mqtt_on_log(self, _client, _userdata, _level, msg):
         self._arlo.vdebug(f"mqtt: log={str(msg)}")
 
-    def mqtt_on_message(self, _client, _userdata, msg):
+    def _mqtt_on_message(self, _client, _userdata, msg):
         self._arlo.debug(f"mqtt: topic={msg.topic}")
-        response = json.loads(msg.payload.decode("utf-8"))
-        self._ev_response(response)
 
-    def _ev_thread_main(self):
+        try:
+            response = json.loads(msg.payload.decode("utf-8"))
 
-        while not self._stopThread:
+            # deal with mqtt specific pieces
+            if response.get("action", "") == "logout":
+                # Logged out? MQTT will log back in until stopped.
+                self._arlo.warning("logged out? did you log in from elsewhere?")
+                return
 
-            # Say we're starting
-            if self._dump_file is not None:
-                with open(self._dump_file, "a") as dump:
-                    time_stamp = now_strftime("%Y-%m-%d %H:%M:%S.%f")
-                    dump.write("{}: {}\n".format(time_stamp, "ev_loop start"))
+            # pass on to general handler
+            self._event_handle_response(response)
 
-            # login again if not first iteration, this will also create a new session
-            while not self._logged_in:
-                with self._lock:
-                    self._lock.wait(5)
-                self._arlo.debug("re-logging in")
-                self._logged_in = self._login()
+        except json.decoder.JSONDecodeError as e:
+            self._arlo.debug("reopening: json error " + str(e))
 
-            try:
-                self._arlo.debug("(re)starting event loop")
-                headers = {
-                    "Host": MQTT_HOST,
-                    "Origin": ORIGIN_HOST,
-                }
+    def _mqtt_main(self):
 
-                # Build a new client_id per login. The last 10 numbers seem to need to be random.
-                self._ev_client_id = f"user_{self._user_id}_" + "".join(
-                    str(randint(0, 9)) for _ in range(10)
+        try:
+            self._arlo.debug("(re)starting mqtt event loop")
+            headers = {
+                "Host": MQTT_HOST,
+                "Origin": ORIGIN_HOST,
+            }
+
+            # Build a new client_id per login. The last 10 numbers seem to need to be random.
+            self._event_client_id = f"user_{self._user_id}_" + "".join(
+                str(random.randint(0, 9)) for _ in range(10)
+            )
+            self._arlo.debug(f"mqtt: client_id={self._event_client_id}")
+
+            # Create and set up the MQTT client.
+            self._event_client = mqtt.Client(
+                client_id=self._event_client_id, transport="websockets"
+            )
+            self._event_client.on_log = self._mqtt_on_log
+            self._event_client.on_connect = self._mqtt_on_connect
+            self._event_client.on_message = self._mqtt_on_message
+            self._event_client.tls_set_context(ssl.create_default_context())
+            self._event_client.username_pw_set(f"{self._user_id}", self._token)
+            self._event_client.ws_set_options(path=MQTT_PATH, headers=headers)
+
+            # Connect.
+            self._event_client.connect(MQTT_HOST, port=443, keepalive=60)
+            self._event_client.loop_forever()
+
+        except Exception as e:
+            # self._arlo.warning('general exception ' + str(e))
+            self._arlo.error(
+                "general-error={}\n{}".format(type(e).__name__, traceback.format_exc())
+            )
+
+    def _sse_reconnected(self):
+        self._arlo.debug("Fetching device list after ev-reconnect")
+        self.devices()
+
+    def _sse_main(self):
+
+        # get stream, restart after requested seconds of inactivity or forced close
+        try:
+            if self._arlo.cfg.stream_timeout == 0:
+                self._arlo.debug("starting stream with no timeout")
+                self._event_client = SSEClient(
+                    self._arlo,
+                    self._arlo.cfg.host + SUBSCRIBE_PATH,
+                    session=self._session,
+                    reconnect_cb=self._sse_reconnected,
                 )
-                self._arlo.debug(f"mqtt: client_id={self._ev_client_id}")
-
-                # Create and setup the MQTT client.
-                self._ev_client = mqtt.Client(
-                    client_id=self._ev_client_id, transport="websockets"
-                )
-                self._ev_client.on_log = self.mqtt_on_log
-                self._ev_client.on_connect = self.mqtt_on_connect
-                self._ev_client.on_message = self.mqtt_on_message
-                self._ev_client.tls_set_context(ssl.create_default_context())
-                self._ev_client.username_pw_set(f"{self._user_id}", self._token)
-                self._ev_client.ws_set_options(path=MQTT_PATH, headers=headers)
-
-                # Connect.
-                self._ev_client.connect(MQTT_HOST, port=443, keepalive=60)
-                self._ev_client.loop_forever()
-
-            except Exception as e:
-                # self._arlo.warning('general exception ' + str(e))
-                self._arlo.error(
-                    "general-error={}\n{}".format(
-                        type(e).__name__, traceback.format_exc()
+            else:
+                self._arlo.debug(
+                    "starting stream with {} timeout".format(
+                        self._arlo.cfg.stream_timeout
                     )
                 )
+                self._event_client = SSEClient(
+                    self._arlo,
+                    self._arlo.cfg.host + SUBSCRIBE_PATH,
+                    session=self._session,
+                    reconnect_cb=self._sse_reconnected,
+                    timeout=self._arlo.cfg.stream_timeout,
+                )
 
-            # Restart login... This may not be completely necessary.
-            self._client = None
-            self._ev_connected = False
-            self._logged_in = False
+            for event in self._event_client:
+
+                # stopped?
+                if event is None:
+                    self._arlo.debug("reopening: no event")
+                    break
+
+                # dig out response
+                try:
+                    response = json.loads(event.data)
+                except json.decoder.JSONDecodeError as e:
+                    self._arlo.debug("reopening: json error " + str(e))
+                    break
+
+                # deal with SSE specific pieces
+                # logged out? signal exited
+                if response.get("action", "") == "logout":
+                    self._arlo.warning("logged out? did you log in from elsewhere?")
+                    break
+
+                # connected - yay!
+                if response.get("status", "") == "connected":
+                    with self._lock:
+                        self._event_connected = True
+                        self._lock.notify_all()
+                    continue
+
+                # pass on to general handler
+                self._event_handle_response(response)
+
+        except requests.exceptions.ConnectionError:
+            self._arlo.warning("event loop timeout")
+        except AttributeError as e:
+            self._arlo.warning("forced close " + str(e))
+        except Exception as e:
+            # self._arlo.warning('general exception ' + str(e))
+            self._arlo.error(
+                "general-error={}\n{}".format(type(e).__name__, traceback.format_exc())
+            )
 
     def start_monitoring(self):
-        self._ev_client = None
-        self._ev_connected = False
-        self._ev_thread = threading.Thread(
-            name="ArloEventStream", target=self._ev_thread_main, args=()
+        self._event_client = None
+        self._event_connected = False
+        self._event_thread = threading.Thread(
+            name="ArloEventStream", target=self._event_main, args=()
         )
-        self._ev_thread.setDaemon(True)
+        self._event_thread.setDaemon(True)
 
         with self._lock:
-            self._ev_thread.start()
-            if not self._ev_connected:
+            self._event_thread.start()
+            count = 0
+            while not self._event_connected and count < 30:
                 self._arlo.debug("waiting for stream up")
-                self._lock.wait(30)
+                self._lock.wait(1)
+                count += 1
 
+        # start logout daemon
+        if self._arlo.cfg.reconnect_every != 0:
+            self._arlo.debug("automatically reconnecting")
+            self._arlo.bg.run_every(self.logout, self._arlo.cfg.reconnect_every)
         self._arlo.debug("stream up")
         return True
-
-    def _ev_stop(self):
-        self._stopThread = True
 
     def _get_tfa(self):
         """Return the 2FA type we're using."""
@@ -744,9 +839,9 @@ class ArloBackEnd(object):
 
     def logout(self):
         self._arlo.debug("trying to logout")
-        self._ev_stop()
-        if self._ev_client is not None:
-            self._ev_client.disconnect()
+        self._event_stop_loop()
+        if self._event_client is not None:
+            self._event_client.disconnect()
         self.put(LOGOUT_PATH)
 
     def notify(self, base, body, timeout=None, wait_for=None):
@@ -948,4 +1043,4 @@ class ArloBackEnd(object):
             )
 
     def ev_inject(self, response):
-        self._ev_dispatcher(response)
+        self._event_dispatcher(response)

--- a/custom_components/aarlo/pyaarlo/cfg.py
+++ b/custom_components/aarlo/pyaarlo/cfg.py
@@ -208,7 +208,6 @@ class ArloCfg(object):
     @property
     def session_file(self):
         return self.storage_dir + "/session.pickle"
-        return None
 
     @property
     def save_session(self):
@@ -255,3 +254,7 @@ class ArloCfg(object):
     @property
     def no_unicode_squash(self):
         return self._kw.get("no_unicode_squash", True)
+
+    @property
+    def use_mqtt(self):
+        return self._kw.get("backend", "mqtt") == "mqtt"

--- a/custom_components/aarlo/pyaarlo/sseclient.py
+++ b/custom_components/aarlo/pyaarlo/sseclient.py
@@ -57,6 +57,9 @@ class SSEClient(object):
     def stop(self):
         self.running = False
 
+    def disconnect(self):
+        self.running = False
+
     def _connect(self):
         if self.last_id:
             self.requests_kwargs["headers"]["Last-Event-ID"] = self.last_id


### PR DESCRIPTION
For some people mqtt doesn't work, they can now add `backend: sse` to revert to
the original behaviour.