### PR TITLE
Fix for aarlo.alarm_set_mode is broken #581

### DIFF
--- a/custom_components/aarlo/alarm_control_panel.py
+++ b/custom_components/aarlo/alarm_control_panel.py
@@ -13,8 +13,8 @@ import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 import voluptuous as vol
 from homeassistant.components import websocket_api
+from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_DOMAIN
 from homeassistant.components.alarm_control_panel import (
-    DOMAIN,
     FORMAT_NUMBER,
     FORMAT_TEXT,
     AlarmControlPanelEntity,
@@ -444,7 +444,7 @@ def alarm_mode_service(hass, call):
     for entity_id in call.data["entity_id"]:
         try:
             mode = call.data["mode"]
-            get_entity_from_domain(hass, DOMAIN, entity_id).set_mode_in_ha(mode)
+            get_entity_from_domain(hass, ALARM_DOMAIN, entity_id).set_mode_in_ha(mode)
             _LOGGER.info("{0} setting mode to {1}".format(entity_id, mode))
         except HomeAssistantError:
             _LOGGER.warning("{0} is not an aarlo alarm device".format(entity_id))


### PR DESCRIPTION
Fix for aarlo.alarm_set_mode is silently has no effect, as you imported two different DOMAIN (s) , where the 1st DOMAIN is the intended on as ALARM_DOMAIN and 2nd DOMAIN as aarlo is the one the has effect in alarm_mode_service function

https://github.com/twrecked/hass-aarlo/issues/581