### PR TITLE
Call stop() on auth failure.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,5 @@
 aarlo
+0.8.0a9: Call stop on auth failure.
 0.8.0a8: Bumped pyaarlo version.
   Fixed DOMAIN handling and mode changes, snapshot...
   Fixed entity_id in callbacks

--- a/custom_components/aarlo/__init__.py
+++ b/custom_components/aarlo/__init__.py
@@ -342,6 +342,7 @@ def login(hass, conf):
             if arlo.is_connected:
                 _LOGGER.debug(f"login succeeded, attempt={attempt}")
                 return arlo
+            arlo.stop()
 
             if attempt == 1:
                 hass.components.persistent_notification.create(


### PR DESCRIPTION
Without this you can get thread leaks.
