### PR TITLE
Version 0.7.x cipher list

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,5 @@
 aarlo/pyaarlo
+0.7.2b13: Added `cipher_list` option.
 0.7.2b12: Fix doorbell capabilities.
   Custom user agent support.
   Added event_id and time to URL paths.

--- a/custom_components.json
+++ b/custom_components.json
@@ -1,6 +1,6 @@
 {
     "aarlo": {
-        "version": "0.7.2b12",
+        "version": "0.7.2b13",
         "local_location": "/custom_components/aarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/custom_components/aarlo/__init__.py",
         "visit_repo": "https://github.com/twrecked/hass-aarlo",
@@ -18,7 +18,7 @@
         ]
     },
     "pyaarlo": {
-        "version": "0.7.2b12",
+        "version": "0.7.2b13",
         "local_location": "/custom_components/aarlo/pyaarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/custom_components/aarlo/pyaarlo/__init__.py",
         "visit_repo": "https://github.com/twrecked/hass-aarlo",

--- a/custom_components/aarlo/__init__.py
+++ b/custom_components/aarlo/__init__.py
@@ -82,6 +82,7 @@ CONF_NO_UNICODE_SQUASH = "no_unicode_squash"
 CONF_SAVE_SESSION = "save_session"
 CONF_BACKEND = "backend"
 CONF_DEFAULT_CIPHERS = "default_ciphers"
+CONF_CIPHER_LIST = "cipher_list"
 
 SCAN_INTERVAL = timedelta(seconds=60)
 PACKET_DUMP = False
@@ -123,6 +124,7 @@ NO_UNICODE_SQUASH = True
 SAVE_SESSION = True
 DEFAULT_BACKEND = "auto"
 DEFAULT_DEFAULT_CIPHERS = False
+DEFAULT_CIPHER_LIST = None
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -203,9 +205,8 @@ CONFIG_SCHEMA = vol.Schema(
                 ): cv.boolean,
                 vol.Optional(CONF_SAVE_SESSION, default=SAVE_SESSION): cv.boolean,
                 vol.Optional(CONF_BACKEND, default=DEFAULT_BACKEND): cv.string,
-                vol.Optional(
-                    CONF_DEFAULT_CIPHERS, default=DEFAULT_DEFAULT_CIPHERS
-                ): cv.boolean,
+                vol.Optional(CONF_DEFAULT_CIPHERS, default=DEFAULT_DEFAULT_CIPHERS): cv.boolean,
+                vol.Optional(CONF_CIPHER_LIST, default=DEFAULT_CIPHER_LIST): cv.string,
             }
         ),
     },
@@ -385,6 +386,7 @@ def login(hass, conf):
     save_session = conf.get(CONF_SAVE_SESSION)
     backend = conf.get(CONF_BACKEND)
     default_ciphers = conf.get(CONF_DEFAULT_CIPHERS)
+    cipher_list = conf.get(CONF_CIPHER_LIST)
 
     # Fix up config
     if conf_dir == "":
@@ -442,6 +444,7 @@ def login(hass, conf):
                 save_session=save_session,
                 backend=backend,
                 default_ciphers=default_ciphers,
+                cipher_list=cipher_list,
                 wait_for_initial_setup=False,
                 verbose_debug=verbose_debug,
             )

--- a/custom_components/aarlo/__init__.py
+++ b/custom_components/aarlo/__init__.py
@@ -28,7 +28,7 @@ from requests.exceptions import ConnectTimeout, HTTPError
 
 from .pyaarlo.constant import DEFAULT_AUTH_HOST, DEFAULT_HOST, SIREN_STATE_KEY
 
-__version__ = "0.7.2b12"
+__version__ = "0.7.2b13"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -124,7 +124,7 @@ NO_UNICODE_SQUASH = True
 SAVE_SESSION = True
 DEFAULT_BACKEND = "auto"
 DEFAULT_DEFAULT_CIPHERS = False
-DEFAULT_CIPHER_LIST = None
+DEFAULT_CIPHER_LIST = ""
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/custom_components/aarlo/manifest.json
+++ b/custom_components/aarlo/manifest.json
@@ -6,6 +6,6 @@
   "dependencies": ["ffmpeg"],
   "codeowners": ["@twrecked"],
   "requirements": ["unidecode","cloudscraper>=1.2.64", "paho-mqtt"],
-  "version": "0.7.2b12",
+  "version": "0.7.2b13",
   "iot_class": "cloud_push"
 }

--- a/custom_components/aarlo/pyaarlo/__init__.py
+++ b/custom_components/aarlo/pyaarlo/__init__.py
@@ -40,7 +40,7 @@ from .util import time_to_arlotime
 
 _LOGGER = logging.getLogger("pyaarlo")
 
-__version__ = "0.7.2b12"
+__version__ = "0.7.2b13"
 
 
 class PyArlo(object):

--- a/custom_components/aarlo/pyaarlo/cfg.py
+++ b/custom_components/aarlo/pyaarlo/cfg.py
@@ -263,4 +263,4 @@ class ArloCfg(object):
     def cipher_list(self):
         if self._kw.get("default_ciphers", False):
             return 'DEFAULT'
-        return self._kw.get("cipher_list", None)
+        return self._kw.get("cipher_list", "")

--- a/custom_components/aarlo/pyaarlo/cfg.py
+++ b/custom_components/aarlo/pyaarlo/cfg.py
@@ -260,5 +260,7 @@ class ArloCfg(object):
         return self._kw.get("backend", "auto")
 
     @property
-    def default_ciphers(self):
-        return self._kw.get("default_ciphers", False)
+    def cipher_list(self):
+        if self._kw.get("default_ciphers", False):
+            return 'DEFAULT'
+        return self._kw.get("cipher_list", None)

--- a/custom_components/aarlo/pyaarlo/tfa.py
+++ b/custom_components/aarlo/pyaarlo/tfa.py
@@ -49,10 +49,11 @@ class Arlo2FAImap:
 
         try:
             # allow default ciphers to be specified
-            if self._arlo.cfg.default_ciphers:
+            cipher_list = self._arlo.cfg.cipher_list
+            if cipher_list is not None:
                 ctx = ssl.create_default_context()
-                ctx.set_ciphers("DEFAULT")
-                self._arlo.debug(f"imap is using DEFAULT ciphers")
+                ctx.set_ciphers(cipher_list)
+                self._arlo.debug(f"imap is using custom ciphers {cipher_list}")
             else:
                 ctx = None
 

--- a/custom_components/aarlo/pyaarlo/tfa.py
+++ b/custom_components/aarlo/pyaarlo/tfa.py
@@ -50,7 +50,7 @@ class Arlo2FAImap:
         try:
             # allow default ciphers to be specified
             cipher_list = self._arlo.cfg.cipher_list
-            if cipher_list is not None:
+            if cipher_list != "":
                 ctx = ssl.create_default_context()
                 ctx.set_ciphers(cipher_list)
                 self._arlo.debug(f"imap is using custom ciphers {cipher_list}")


### PR DESCRIPTION
Newer Python can stop people from connecting to older IMAP services not
supporting newer cipher suites. Users can now provide a custom cipher
list.