### PR TITLE
Added `cipher_list` option.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,6 @@
 aarlo
+0.8.0a10: Add cipher_list support.
+  Bumped pyyaarlo version.
 0.8.0a9: Call stop on auth failure.
   Smarter backend detection.
   Custom user agent support.

--- a/custom_components/aarlo/__init__.py
+++ b/custom_components/aarlo/__init__.py
@@ -28,7 +28,7 @@ from requests.exceptions import ConnectTimeout, HTTPError
 
 from .const import *
 
-__version__ = "0.8.0a9"
+__version__ = "0.8.0a10"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -102,6 +102,7 @@ CONFIG_SCHEMA = vol.Schema(
                 ): cv.boolean,
                 vol.Optional(CONF_SAVE_SESSION, default=SAVE_SESSION): cv.boolean,
                 vol.Optional(CONF_BACKEND, default=DEFAULT_BACKEND): cv.string,
+                vol.Optional(CONF_CIPHER_LIST, default=DEFAULT_CIPHER_LIST): cv.string,
             }
         ),
     },
@@ -282,6 +283,7 @@ def login(hass, conf):
     no_unicode_squash = conf.get(CONF_NO_UNICODE_SQUASH)
     save_session = conf.get(CONF_SAVE_SESSION)
     backend = conf.get(CONF_BACKEND)
+    cipher_list = conf.get(CONF_CIPHER_LIST)
 
     # Fix up config
     if conf_dir == "":
@@ -335,6 +337,7 @@ def login(hass, conf):
                 save_media_to=save_media_to,
                 save_session=save_session,
                 backend=backend,
+                cipher_list=cipher_list,
                 wait_for_initial_setup=False,
                 verbose_debug=verbose_debug,
             )

--- a/custom_components/aarlo/const.py
+++ b/custom_components/aarlo/const.py
@@ -49,6 +49,7 @@ CONF_SAVE_MEDIA_TO = "save_media_to"
 CONF_NO_UNICODE_SQUASH = "no_unicode_squash"
 CONF_SAVE_SESSION = "save_session"
 CONF_BACKEND = "backend"
+CONF_CIPHER_LIST = "cipher_list"
 
 SCAN_INTERVAL = timedelta(seconds=60)
 PACKET_DUMP = False
@@ -86,3 +87,4 @@ SAVE_MEDIA_TO = ""
 NO_UNICODE_SQUASH = True
 SAVE_SESSION = True
 DEFAULT_BACKEND = "auto"
+DEFAULT_CIPHER_LIST = ""

--- a/custom_components/aarlo/manifest.json
+++ b/custom_components/aarlo/manifest.json
@@ -12,8 +12,8 @@
   ],
   "requirements": [
     "unidecode",
-    "pyaarlo>=0.8.0b3"
+    "pyaarlo>=0.8.0b4"
   ],
-  "version": "0.8.0a9",
+  "version": "0.8.0a10",
   "iot_class": "cloud_push"
 }


### PR DESCRIPTION
Newer Python can stop people from connecting to older IMAP services not supporting newer cipher suites. Users can now provide a custom cipher list.