### PR TITLE
Remove tfa_retries and tfa_delay from README.md as they are invalid config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,8 +462,6 @@ PUSH 2FA _Arlo_ is used when account is set for 2FA to phone app.
 aarlo:
   tfa_source: push
   tfa_type: PUSH
-  tfa_retries: 5 # optional: default 5; attempts to check for push approved
-  tfa_delay: 5 # optional: default 5; seconds of delay between retries
 ```
 
 


### PR DESCRIPTION
Remove tfa_retries and tfa_delay from sample docs. Their presence prevents startup:

ERROR (MainThread) [homeassistant.config] Invalid config for [aarlo]: [tfa_retries] is an invalid option for [aarlo]. Check: aarlo->aarlo->tfa_retries. (See /config/configuration.yaml, line 284). Please check the docs at https://github.com/twrecked/hass-aarlo/blob/master/README.md

ERROR (MainThread) [homeassistant.components.homeassistant] The system cannot restart because the configuration is not valid: Invalid config for [aarlo]: [tfa_delay] is an invalid option for [aarlo]. Check: aarlo->aarlo->tfa_delay. (See /config/configuration.yaml, line 284).