### PR TITLE
Fixed device classes.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,5 @@
 aarlo/pyaarlo
+0.7.3: Removed DEVICE_CLASS_ constants.
 0.7.2b13: Added `cipher_list` option.
 0.7.2b12: Fix doorbell capabilities.
   Custom user agent support.

--- a/custom_components/aarlo/__init__.py
+++ b/custom_components/aarlo/__init__.py
@@ -28,7 +28,7 @@ from requests.exceptions import ConnectTimeout, HTTPError
 
 from .pyaarlo.constant import DEFAULT_AUTH_HOST, DEFAULT_HOST, SIREN_STATE_KEY
 
-__version__ = "0.7.2b13"
+__version__ = "0.7.3"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/aarlo/media_player.py
+++ b/custom_components/aarlo/media_player.py
@@ -3,7 +3,7 @@ import logging
 from abc import ABC
 
 from homeassistant.components.media_player import (
-    DEVICE_CLASS_SPEAKER,
+    MediaPlayerDeviceClass,
     MediaPlayerEntity,
 )
 from homeassistant.components.media_player.const import (
@@ -176,7 +176,7 @@ class ArloMediaPlayer(MediaPlayerEntity, ABC):
     @property
     def device_class(self):
         """Return the device class of the media player."""
-        return DEVICE_CLASS_SPEAKER
+        return MediaPlayerDeviceClass.SPEAKER
 
     @property
     def icon(self):

--- a/custom_components/aarlo/pyaarlo/__init__.py
+++ b/custom_components/aarlo/pyaarlo/__init__.py
@@ -40,7 +40,7 @@ from .util import time_to_arlotime
 
 _LOGGER = logging.getLogger("pyaarlo")
 
-__version__ = "0.7.2b13"
+__version__ = "0.7.3"
 
 
 class PyArlo(object):

--- a/custom_components/aarlo/sensor.py
+++ b/custom_components/aarlo/sensor.py
@@ -5,21 +5,19 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.arlo/
 """
 import logging
+import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-import voluptuous as vol
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     CONF_MONITORED_CONDITIONS,
-    DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_TEMPERATURE,
     TEMP_CELSIUS,
 )
 from homeassistant.core import callback
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
+from homeassistant.components.sensor import SensorDeviceClass
 
 from . import COMPONENT_ATTRIBUTION, COMPONENT_BRAND, COMPONENT_DATA, COMPONENT_DOMAIN
 from .pyaarlo.constant import (
@@ -156,11 +154,11 @@ class ArloSensor(Entity):
     def device_class(self):
         """Return the device class of the sensor."""
         if self._sensor_type == "temperature":
-            return DEVICE_CLASS_TEMPERATURE
+            return SensorDeviceClass.TEMPERATURE
         if self._sensor_type == "humidity":
-            return DEVICE_CLASS_HUMIDITY
+            return SensorDeviceClass.HUMIDITY
         if self._sensor_type == "battery_level":
-            return DEVICE_CLASS_BATTERY
+            return SensorDeviceClass.BATTERY
         return None
 
     @property


### PR DESCRIPTION
DEVICE_CLASS_* was deprecated in 2021.12; change to new mechanism.

Bump revision.