### PR TITLE
Limit retries.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,6 @@
 aarlo
+0.8.0a14:
+  Limit retries to (try to) prevent cloudflare lockouts
 0.8.0a13:
   Handle Arlo backend changes.
   Make MQTT more configurable.

--- a/custom_components.json
+++ b/custom_components.json
@@ -1,6 +1,6 @@
 {
     "aarlo": {
-        "version": "0.8.0a13",
+        "version": "0.8.0a14",
         "local_location": "/custom_components/aarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/custom_components/aarlo/__init__.py",
         "visit_repo": "https://github.com/twrecked/hass-aarlo",
@@ -18,7 +18,7 @@
         ]
     },
     "pyaarlo": {
-        "version": "0.8.0a13",
+        "version": "0.8.0a14",
         "local_location": "/custom_components/aarlo/pyaarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/custom_components/aarlo/pyaarlo/__init__.py",
         "visit_repo": "https://github.com/twrecked/hass-aarlo",

--- a/custom_components/aarlo/__init__.py
+++ b/custom_components/aarlo/__init__.py
@@ -28,7 +28,7 @@ from requests.exceptions import ConnectTimeout, HTTPError
 
 from .const import *
 
-__version__ = "0.8.0a13"
+__version__ = "0.8.0a14"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -389,6 +389,9 @@ def login(hass, conf):
 
         # line up a retry
         attempt = attempt + 1
+        if attempt == 5:
+            _LOGGER.error(f"unable to connect to Arlo: stopping retries, too may failures")
+            return None
         time.sleep(sleep)
         sleep = min(300, sleep * 2)
 

--- a/custom_components/aarlo/manifest.json
+++ b/custom_components/aarlo/manifest.json
@@ -14,6 +14,6 @@
     "unidecode",
     "pyaarlo>=0.8.0b7"
   ],
-  "version": "0.8.0a13",
+  "version": "0.8.0a14",
   "iot_class": "cloud_push"
 }


### PR DESCRIPTION
The old code would try to login forever. This might have been causing lockout issues with cloudflare. This change limits the number of retries to 5 attempts.