### PR TITLE
Limit retries.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,6 @@
 aarlo/pyaarlo
+0.7.4b15:
+  Limit number of logins to help with cloudflare issues
 0.7.4b14:
   Bump cloudscraper revision.
   Update Arlo headers.

--- a/custom_components.json
+++ b/custom_components.json
@@ -1,6 +1,6 @@
 {
     "aarlo": {
-        "version": "0.7.4b14",
+        "version": "0.7.4b15",
         "local_location": "/custom_components/aarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/custom_components/aarlo/__init__.py",
         "visit_repo": "https://github.com/twrecked/hass-aarlo",
@@ -18,7 +18,7 @@
         ]
     },
     "pyaarlo": {
-        "version": "0.7.4b14",
+        "version": "0.7.4b15",
         "local_location": "/custom_components/aarlo/pyaarlo/__init__.py",
         "remote_location": "https://raw.githubusercontent.com/twrecked/hass-aarlo/master/custom_components/aarlo/pyaarlo/__init__.py",
         "visit_repo": "https://github.com/twrecked/hass-aarlo",

--- a/custom_components/aarlo/__init__.py
+++ b/custom_components/aarlo/__init__.py
@@ -33,7 +33,7 @@ from .pyaarlo.constant import (
     SIREN_STATE_KEY
 )
 
-__version__ = "0.7.4b14"
+__version__ = "0.7.4b15"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -511,6 +511,9 @@ def login(hass, conf):
 
         # line up a retry
         attempt = attempt + 1
+        if attempt == 5:
+            _LOGGER.error(f"unable to connect to Arlo: stopping retries, too may failures")
+            return None
         time.sleep(sleep)
         sleep = min(300, sleep * 2)
 

--- a/custom_components/aarlo/manifest.json
+++ b/custom_components/aarlo/manifest.json
@@ -6,6 +6,6 @@
   "dependencies": ["ffmpeg"],
   "codeowners": ["@twrecked"],
   "requirements": ["unidecode","cloudscraper>=1.2.71", "paho-mqtt"],
-  "version": "0.7.4b14",
+  "version": "0.7.4b15",
   "iot_class": "cloud_push"
 }

--- a/custom_components/aarlo/pyaarlo/__init__.py
+++ b/custom_components/aarlo/pyaarlo/__init__.py
@@ -44,7 +44,7 @@ from .util import time_to_arlotime
 
 _LOGGER = logging.getLogger("pyaarlo")
 
-__version__ = "0.7.4b14"
+__version__ = "0.7.4b15"
 
 
 class PyArlo(object):


### PR DESCRIPTION
The old code would try to login forever. This might have been causing lockout issues with cloudflare. This change limits the number of retries to 5 attempts.