### PR TITLE
Fix entities when adding the Integration

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,7 @@
 aarlo
+0.8.1a4
+  Fix initial options to create devices.
+  Fix integration naming.
 0.8.1a3
   Allow pyaarlo config to be passed from `/config/aarlo.yaml`
   Bump pyaarlo revision.

--- a/custom_components/aarlo/__init__.py
+++ b/custom_components/aarlo/__init__.py
@@ -45,7 +45,7 @@ from .utils import get_entity_from_domain
 from .cfg import BlendedCfg, PyaarloCfg
 
 
-__version__ = "0.8.1a3"
+__version__ = "0.8.1a4"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/aarlo/cfg.py
+++ b/custom_components/aarlo/cfg.py
@@ -249,6 +249,43 @@ SWITCH_SCHEMA = vol.Schema({
 
 AARLO_CONFIG_FILE = "/config/aarlo.yaml"
 
+DEFAULT_OPTIONS = {
+    "alarm_control_panel_disarmed_mode_name": "disarmed",
+    "alarm_control_panel_home_mode_name": "home",
+    "alarm_control_panel_away_mode_name": "away",
+    "alarm_control_panel_night_mode_name": "night",
+    "alarm_control_panel_code_arm_required": False,
+    "alarm_control_panel_code_disarm_required": False,
+    "alarm_control_panel_trigger_time": 60,
+    "alarm_control_panel_alarm_volume": 3,
+    "binary_sensor_sound": True,
+    "binary_sensor_motion": True,
+    "binary_sensor_ding": True,
+    "binary_sensor_cry": True,
+    "binary_sensor_connectivity": True,
+    "binary_sensor_contact": True,
+    "binary_sensor_light": True,
+    "binary_sensor_tamper": True,
+    "binary_sensor_leak": True,
+    "sensor_last_capture": True,
+    "sensor_total_cameras": True,
+    "sensor_recent_activity": True,
+    "sensor_captured_today": True,
+    "sensor_battery_level": True,
+    "sensor_signal_strength": True,
+    "sensor_temperature": True,
+    "sensor_humidity": True,
+    "sensor_air_quality": True,
+    "switch_siren": True,
+    "switch_all_sirens": True,
+    "switch_siren_allow_off": True,
+    "switch_siren_volume": 3,
+    "switch_siren_duration": 10,
+    "switch_snapshot": True,
+    "switch_snapshot_timeout": 15,
+    "switch_doorbell_silence": True
+}
+
 
 def _fix_config(config):
     """Find and return the aarlo entry from any platform config.
@@ -318,6 +355,10 @@ class BlendedCfg(object):
 
     def _merge(self, data, options):
         """Rebuild config from flow data and options."""
+
+        if not options:
+            _LOGGER.debug("empty options, using defaults")
+            options = DEFAULT_OPTIONS
 
         self._main_config = {**data, **self._main_config}
         self._alarm_config = ALARM_SCHEMA(_extract_platform_config(options, "alarm_control_panel_"))

--- a/custom_components/aarlo/config_flow.py
+++ b/custom_components/aarlo/config_flow.py
@@ -22,6 +22,7 @@ from .const import (
 )
 from .cfg import UpgradeCfg
 
+
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_IMPORTED_NAME = "imported"
@@ -123,7 +124,7 @@ class AarloFlowHandler(config_entries.ConfigFlow, domain=COMPONENT_DOMAIN):
             if not errors:
                 _LOGGER.debug(f"aarlo-config={config}")
                 return self.async_create_entry(
-                    title=f"Aarlo for ${self._username}",
+                    title=f"Aarlo for {info[CONF_USERNAME]}",
                     data=config
                 )
 

--- a/custom_components/aarlo/manifest.json
+++ b/custom_components/aarlo/manifest.json
@@ -15,5 +15,5 @@
     "unidecode",
     "pyaarlo>=0.8.0.1"
   ],
-  "version": "0.8.1a3"
+  "version": "0.8.1a4"
 }


### PR DESCRIPTION
There were no entities being created by default when a user added the _Arlo_ integration. This fixes that issue.

It also fixes the integration naming.
