### PR TITLE
Fix many non-thread-safe operations

### DIFF
--- a/custom_components/aarlo/alarm_control_panel.py
+++ b/custom_components/aarlo/alarm_control_panel.py
@@ -272,11 +272,10 @@ class ArloBaseStation(AlarmControlPanelEntity):
     async def async_added_to_hass(self):
         """Register callbacks."""
 
-        @callback
         def update_state(_device, _attr, _value):
             _LOGGER.debug("callback:{self._attr_name}:{attr}:{str(value)}")
             self._attr_state = self._get_state_from_ha(self._base.attribute(MODE_KEY))
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
         self._attr_state = self._get_state_from_ha(self._base.attribute(MODE_KEY, STATE_ALARM_ARLO_ARMED))
         self._base.add_attr_callback(MODE_KEY, update_state)
@@ -320,7 +319,7 @@ class ArloBaseStation(AlarmControlPanelEntity):
             self._timer = async_track_point_in_time(
                 self.hass, HassJob(self._async_stop_trigger), self._trigger_till
             )
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
     def alarm_clear(self):
         self._trigger_till = None
@@ -419,11 +418,10 @@ class ArloLocation(AlarmControlPanelEntity):
     async def async_added_to_hass(self):
         """Register callbacks."""
 
-        @callback
         def update_state(_device, attr, value):
             _LOGGER.debug(f"callback:{self._attr_name}:{attr}:{str(value)}")
             self._attr_state = self._get_state_from_ha(self._location.attribute(MODE_KEY))
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
         self._attr_state = self._get_state_from_ha(self._location.attribute(MODE_KEY, "Stand By"))
         self._location.add_attr_callback(MODE_KEY, update_state)

--- a/custom_components/aarlo/binary_sensor.py
+++ b/custom_components/aarlo/binary_sensor.py
@@ -155,12 +155,11 @@ class ArloBinarySensor(BinarySensorEntity):
     async def async_added_to_hass(self):
         """Register callbacks."""
 
-        @callback
         def update_state(_device, attr, value):
             _LOGGER.debug("callback:" + self._attr_name + ":" + attr + ":" + str(value)[:80])
             if self._main_attr == attr:
                 self._attr_is_on = self._map_value(attr, value)
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
         if self._main_attr is not None:
             self._attr_is_on = self._map_value(self._main_attr, self._device.attribute(self._main_attr))

--- a/custom_components/aarlo/camera.py
+++ b/custom_components/aarlo/camera.py
@@ -337,7 +337,6 @@ class ArloCam(Camera):
     async def async_added_to_hass(self):
         """Register callbacks."""
 
-        @callback
         def update_state(_device, attr, value):
             _LOGGER.debug(f"callback:{self._attr_name}:{attr}:{str(value)[:120]}")
 
@@ -407,7 +406,7 @@ class ArloCam(Camera):
                 self._attr_is_on = not value
 
             # Signal changes.
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
         self._camera.add_attr_callback(ACTIVITY_STATE_KEY, update_state)
         self._camera.add_attr_callback(CHARGER_KEY, update_state)

--- a/custom_components/aarlo/light.py
+++ b/custom_components/aarlo/light.py
@@ -119,14 +119,13 @@ class ArloLight(LightEntity):
     async def async_added_to_hass(self):
         """Register callbacks."""
 
-        @callback
         def update_state(_light, attr, value):
             _LOGGER.debug(f"callback:{self._attr_name}:attr:{str(value)[:80]}")
             if attr == LAMP_STATE_KEY:
                 self._attr_is_on = to_bool(value)
             if attr == BRIGHTNESS_KEY:
                 self._attr_brightness = value
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
         self._attr_is_on = to_bool(self._light.attribute(LAMP_STATE_KEY, default="off"))
         self._attr_brightness = self._light.attribute(BRIGHTNESS_KEY, default=255)
@@ -229,14 +228,13 @@ class ArloNightLight(ArloLight):
     async def async_added_to_hass(self):
         """Register callbacks."""
 
-        @callback
         def update_attr(_light, attr, value):
             _LOGGER.debug(f"callback:{self._attr_name}:{attr}:{str(value)[:80]}")
             if attr == LIGHT_BRIGHTNESS_KEY:
                 self._attr_brightness = value
             if attr == LIGHT_MODE_KEY:
                 self._set_light_mode(value)
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
         self._attr_brightness = self._light.attribute(LIGHT_BRIGHTNESS_KEY, default=255)
         self._set_light_mode(self._light.attribute(LIGHT_MODE_KEY))
@@ -317,11 +315,10 @@ class ArloFloodLight(ArloLight):
                 self._sleep_time = None
                 self._sleep_time_rel = None
 
-        @callback
         def update_attr(_light, attr, value):
             _LOGGER.debug(f"callback:{self._attr_name}:{attr}:{str(value)[:80]}")
             set_states(value)
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
         floodlight = self._light.attribute(FLOODLIGHT_KEY, default={})
         set_states(floodlight)
@@ -384,14 +381,13 @@ class ArloSpotlight(ArloLight):
     async def async_added_to_hass(self):
         """Register callbacks."""
 
-        @callback
         def update_attr(_light, attr, value):
             _LOGGER.debug(f"callback:{self._attr_name}:{attr}:{str(value)[:80]}")
             if attr == SPOTLIGHT_KEY:
                 self._attr_is_on = to_bool(value)
             if attr == SPOTLIGHT_BRIGHTNESS_KEY:
                 self._attr_brightness = value / 100 * 255
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
         self._attr_is_on = to_bool(self._light.attribute(SPOTLIGHT_KEY, default="off"))
         self._attr_brightness = self._light.attribute(SPOTLIGHT_BRIGHTNESS_KEY, default=255)

--- a/custom_components/aarlo/media_player.py
+++ b/custom_components/aarlo/media_player.py
@@ -122,7 +122,6 @@ class ArloMediaPlayer(MediaPlayerEntity):
     async def async_added_to_hass(self):
         """Register callbacks."""
 
-        @callback
         def update_state(_device, attr, props):
             _LOGGER.info(f"callback:{self._attr_name}:{attr}:{str(props)[:80]}")
             if attr == "status":
@@ -147,7 +146,7 @@ class ArloMediaPlayer(MediaPlayerEntity):
             elif attr == "playlist":
                 self._playlist = props
 
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
         self._device.add_attr_callback("config", update_state)
         self._device.add_attr_callback("speaker", update_state)

--- a/custom_components/aarlo/sensor.py
+++ b/custom_components/aarlo/sensor.py
@@ -160,11 +160,10 @@ class ArloSensor(Entity):
     async def async_added_to_hass(self):
         """Register callbacks."""
 
-        @callback
         def update_state(_device, attr, value):
             _LOGGER.debug("callback:" + self._attr_name + ":" + attr + ":" + str(value)[:80])
             self._attr_state = value
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
         if self._main_attr is not None:
             self._attr_state = self._device.attribute(self._main_attr)

--- a/custom_components/aarlo/siren.py
+++ b/custom_components/aarlo/siren.py
@@ -97,11 +97,10 @@ class AarloSirenBase(SirenEntity):
     async def async_added_to_hass(self):
         """Register callbacks."""
 
-        @callback
         def update_state(_device, attr, value):
             _LOGGER.debug(f"siren-callback:{self._attr_name}:{attr}:{str(value)[:80]}")
             self._attr_is_on = any(to_bool(siren.siren_state) for siren in self._sirens)
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
         for siren in self._sirens:
             _LOGGER.debug(f"register siren callbacks for {siren.name}")
@@ -117,7 +116,7 @@ class AarloSirenBase(SirenEntity):
 
         # Flip us on. update_state should confirm this.
         self._attr_is_on = True
-        self.async_schedule_update_ha_state()
+        self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the sirens off."""

--- a/custom_components/aarlo/switch.py
+++ b/custom_components/aarlo/switch.py
@@ -226,11 +226,10 @@ class AarloSirenSwitch(AarloSirenBaseSwitch):
     async def async_added_to_hass(self):
         """Register callbacks."""
 
-        @callback
         def update_state(_device, attr, value):
             _LOGGER.debug(f"siren-callback:{self._attr_name}:{attr}:{str(value)[:80]}")
             self._attr_is_on = to_bool(value)
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
         _LOGGER.debug(f"register siren callbacks for {self._device.name}")
         self._device.add_attr_callback(SIREN_STATE_KEY, update_state)
@@ -266,7 +265,6 @@ class AarloAllSirensSwitch(AarloSirenBaseSwitch):
     async def async_added_to_hass(self):
         """Register callbacks."""
 
-        @callback
         def update_state(_device, attr, value):
             _LOGGER.debug(f"all-siren-callback:{self._attr_name}:{attr}:{str(value)[:80]}")
 
@@ -275,7 +273,7 @@ class AarloAllSirensSwitch(AarloSirenBaseSwitch):
                 if device.siren_state == "on":
                     is_on = True
             self._attr_is_on = is_on
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
         for device in self._devices:
             _LOGGER.debug(f"register all siren callbacks for {device.name}")
@@ -309,13 +307,12 @@ class AarloSnapshotSwitch(AarloSwitch):
     async def async_added_to_hass(self):
         """Register callbacks."""
 
-        @callback
         def update_state(_device, attr, value):
             _LOGGER.debug(f"snapshot-callback:{self._attr_name}:{attr}:{str(value)[:80]}")
             # XXX beef this check up in pyaarlo; idle == not taking a snapshot
             # self._attr_is_on = self._device.is_taking_snapshot
             self._attr_is_on = "snapshot" in value.lower()
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
         self._device.add_attr_callback(ACTIVITY_STATE_KEY, update_state)
 
@@ -351,7 +348,6 @@ class AarloSilentModeBaseSwitch(AarloSwitch):
     async def async_added_to_hass(self):
         """Register callbacks."""
 
-        @callback
         def update_state(_device, attr, value):
             _LOGGER.debug(f"callback:{self._attr_name}:{attr}:{str(value)[:100]}")
             if self._block == "calls":
@@ -360,7 +356,7 @@ class AarloSilentModeBaseSwitch(AarloSwitch):
                 self._attr_is_on = self._device.chimes_are_silenced
             else:
                 self._attr_is_on = self._device.is_silenced
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
         self._device.add_attr_callback(SILENT_MODE_KEY, update_state)
 


### PR DESCRIPTION
I don't use this integration so I can't test this change.  

The async API was being called from another thread. Its only safe to call the async API from the event loop.

This fixes the ones that I found with a cursory review. There are probably more

fixes #907