### PR TITLE
Alarm on upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Fine tune the alarm settings:
 
 _Night Mode_; _Arlo_ will not have one of these unless you create it
 
+If you need to clear the alarm code enter `no code needed`. _I will look to make this accept a blank entry..._
 
 ### Binary Sensors Screen
 

--- a/changelog
+++ b/changelog
@@ -1,4 +1,6 @@
 aarlo
+0.8.1.2
+  Fix alarm mode upgrade issue.
 0.8.1.1
   Fix some deprecated warnings.
 0.8.1

--- a/custom_components/aarlo/__init__.py
+++ b/custom_components/aarlo/__init__.py
@@ -53,7 +53,7 @@ from .utils import get_entity_from_domain
 from .cfg import BlendedCfg, PyaarloCfg
 
 
-__version__ = "0.8.1.1"
+__version__ = "0.8.1.2"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/aarlo/cfg.py
+++ b/custom_components/aarlo/cfg.py
@@ -242,10 +242,10 @@ SWITCH_SCHEMA = vol.Schema({
 })
 
 DEFAULT_OPTIONS = {
-    "alarm_control_panel_disarmed_mode_name": "disarmed",
-    "alarm_control_panel_home_mode_name": "home",
-    "alarm_control_panel_away_mode_name": "away",
-    "alarm_control_panel_night_mode_name": "night",
+    "alarm_control_panel_disarmed_mode_name": STATE_ALARM_DISARMED,
+    "alarm_control_panel_home_mode_name": STATE_ALARM_ARLO_HOME,
+    "alarm_control_panel_away_mode_name": STATE_ALARM_ARLO_ARMED,
+    "alarm_control_panel_night_mode_name": STATE_ALARM_ARLO_NIGHT,
     "alarm_control_panel_code_arm_required": False,
     "alarm_control_panel_code_disarm_required": False,
     "alarm_control_panel_trigger_time": 60,

--- a/custom_components/aarlo/config_flow.py
+++ b/custom_components/aarlo/config_flow.py
@@ -5,7 +5,11 @@ import voluptuous as vol
 from typing import Any
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import (
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    STATE_ALARM_DISARMED
+)
 from homeassistant.core import callback
 from homeassistant.helpers.selector import SelectOptionDict, \
     SelectSelector, SelectSelectorConfig, SelectSelectorMode
@@ -19,6 +23,9 @@ from .const import (
     CONF_TFA_TYPE,
     CONF_TFA_USERNAME,
     COMPONENT_DOMAIN,
+    STATE_ALARM_ARLO_ARMED,
+    STATE_ALARM_ARLO_HOME,
+    STATE_ALARM_ARLO_NIGHT
 )
 from .cfg import UpgradeCfg
 
@@ -200,13 +207,17 @@ class ArloOptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional("alarm_control_panel_code",
                              default=options.get("alarm_control_panel_code", "no code needed")): str,
                 vol.Optional("alarm_control_panel_disarmed_mode_name",
-                             default=options.get("alarm_control_panel_disarmed_mode_name", "disarmed")): str,
+                             default=options.get("alarm_control_panel_disarmed_mode_name",
+                                                 STATE_ALARM_DISARMED)): str,
                 vol.Optional("alarm_control_panel_home_mode_name",
-                             default=options.get("alarm_control_panel_home_mode_name", "home")): str,
+                             default=options.get("alarm_control_panel_home_mode_name",
+                                                 STATE_ALARM_ARLO_HOME)): str,
                 vol.Optional("alarm_control_panel_away_mode_name",
-                             default=options.get("alarm_control_panel_away_mode_name", "away")): str,
+                             default=options.get("alarm_control_panel_away_mode_name",
+                                                 STATE_ALARM_ARLO_ARMED)): str,
                 vol.Optional("alarm_control_panel_night_mode_name",
-                             default=options.get("alarm_control_panel_night_mode_name", "night")): str,
+                             default=options.get("alarm_control_panel_night_mode_name",
+                                                 STATE_ALARM_ARLO_NIGHT)): str,
                 vol.Optional("alarm_control_panel_code_arm_required",
                              default=options.get("alarm_control_panel_code_arm_required", False)): bool,
                 vol.Optional("alarm_control_panel_code_disarm_required",

--- a/custom_components/aarlo/manifest.json
+++ b/custom_components/aarlo/manifest.json
@@ -15,5 +15,5 @@
     "unidecode",
     "pyaarlo>=0.8.0.6"
   ],
-  "version": "0.8.1.1"
+  "version": "0.8.1.2"
 }


### PR DESCRIPTION
When upgrading from 0.7 the wrong default alarm code for away was used.
