### PR TITLE
fix: preserve mode name case for V3 custom mode resolution

### DIFF
--- a/custom_components/aarlo/alarm_control_panel.py
+++ b/custom_components/aarlo/alarm_control_panel.py
@@ -329,13 +329,12 @@ class ArloBaseStation(AlarmControlPanelEntity):
 
     def set_mode_in_ha(self, mode):
         """convert Home Assistant state to Arlo mode."""
-        lmode = mode.lower()
-        if lmode == self._disarmed_mode_name:
+        if mode.lower() == self._disarmed_mode_name.lower():
             if self._trigger_till is not None:
                 _LOGGER.debug(f"{self._attr_name} disarming/silencing")
                 self.alarm_clear()
-        _LOGGER.debug(f"{self._attr_name} set mode to {lmode}")
-        self._base.mode = lmode
+        _LOGGER.debug(f"{self._attr_name} set mode to {mode}")
+        self._base.mode = mode
 
     def siren_on(self, duration=30, volume=10):
         if self._base.has_capability(SIREN_STATE_KEY):

--- a/custom_components/aarlo/manifest.json
+++ b/custom_components/aarlo/manifest.json
@@ -13,7 +13,7 @@
   "issue_tracker": "https://github.com/twrecked/hass-aarlo/issues",
   "requirements": [
     "unidecode",
-    "pyaarlo==0.8.0.17",
+    "pyaarlo@ git+https://github.com/GuiPoM/pyaarlo.git@fix/v3-custom-modes",
     "aiofiles"
   ],
   "version": "0.8.1.19"


### PR DESCRIPTION
## Dependency

This PR requires https://github.com/twrecked/pyaarlo/pull/196 to be merged first.

## Problem

After Arlo's forced migration to V3 API, the alarm control panel stopped
working correctly for accounts with custom modes. The root cause is that in
V3, modes are managed at the location level, not the base station level.

## Change

In `alarm_control_panel.py`, `ArloBaseStation.set_mode_in_ha()` was lowercasing
the mode name before passing it to pyaarlo:

```python
# Before
lmode = mode.lower()
self._base.mode = lmode

# After
self._base.mode = mode  # preserve case for pyaarlo's case-insensitive lookup
```

pyaarlo (see companion PR) now handles V3 mode delegation from base station
to location, with case-insensitive custom mode name resolution. The original
case must be preserved so pyaarlo can match the configured mode name against
the custom mode cache.

## Testing

Tested on VMB5000 firmware 0.8.1.19 with custom modes and migrated V2 modes.
All 4 alarm panel modes (disarm, away, home, night) work correctly with
bidirectional sync between HA and the Arlo app.
