### PR TITLE
feat: add native SIP/WebRTC live streaming for cameras that support it

### DIFF
--- a/README-advanced.md
+++ b/README-advanced.md
@@ -8,6 +8,7 @@
 * [Saving Media](#saving-media)
 * [Streaming](#streaming)
   * [Direct Streaming](#direct-streaming)
+  * [SIP/WebRTC Streaming](#sipwebrtc-streaming)
   * [Further Help](#further-help)
 * [Snapshots](#snapshots)
   * [Other](#other)
@@ -119,6 +120,35 @@ You can not stream directly to Apple devices, they don't support `mpeg-dash`.
 Internally the code will use non-direct streaming as needed. For example, to save recording into the _Arlo_ library of longer than 30 seconds the code must open a stream to the _Arlo_ servers, it can only do this in non-direct mode because the stream component doesn't support `mpeg-dash`.
 
 To use it on your `aarlo-glance` card you need to add `direct` to the `image_view` options of the card. You can mix direct and non-direct cards on the UI.
+
+## SIP/WebRTC Streaming
+
+Newer _Arlo_ cameras support a second, completely separate live-view engine:
+signalling over SIP-in-a-WebSocket, media over _WebRTC_. This is what
+`my.arlo.com` and the official apps actually use. There is no `rtsps://` relay
+and no `ffmpeg` transcode - the video goes straight from the camera to your
+browser, so it starts faster and costs your _Home Assistant_ server almost
+nothing.
+
+There is nothing to configure. At startup the integration asks _Arlo_ which of
+your cameras declare SIP support, and those cameras are set up as native
+_WebRTC_ cameras. Everything else - snapshots, the library, the siren,
+recording, and the `aarlo-glance` card's own streaming - is unchanged and still
+goes over RTSPS. Cameras that don't declare SIP support are untouched.
+
+Things worth knowing:
+
+- A _WebRTC_ camera advertises `web_rtc` to the frontend **instead of** `hls`.
+  The standard more-info dialog will use _WebRTC_ for those cameras. The
+  `aarlo-glance` card uses its own websocket and is not affected either way.
+- The camera serves one live stream at a time. Opening the stream in a second
+  place hangs up the first.
+- _Arlo_'s firmware will not run both engines at once - you will see
+  _"SIP Streaming in progress, RTSP Streaming is not allowed"_ if something
+  tries to start a recording while a _WebRTC_ stream is live.
+- Media is peer-to-peer between your browser and _Arlo_. If the browser is on a
+  network that blocks outbound UDP it will fall back to _Arlo_'s TURN servers,
+  which the integration passes through automatically.
 
 ## Further Help
 

--- a/custom_components/aarlo/camera.py
+++ b/custom_components/aarlo/camera.py
@@ -27,7 +27,9 @@ from homeassistant.components.camera import (
     CameraEntityFeature,
     DOMAIN as CAMERA_DOMAIN,
     SERVICE_RECORD,
-    StreamType
+    WebRTCAnswer,
+    WebRTCClientConfiguration,
+    WebRTCSendMessage,
 )
 from homeassistant.components.ffmpeg import DATA_FFMPEG
 from homeassistant.const import (
@@ -36,14 +38,16 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_FILENAME,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_aiohttp_proxy_stream
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.config_entries import ConfigEntry
+from webrtc_models import RTCIceServer
 
 import pyaarlo
+from pyaarlo.sip import ArloSipError
 from pyaarlo.constant import (
     ACTIVITY_STATE_KEY,
     CHARGER_KEY,
@@ -182,6 +186,24 @@ SCHEMA_WS_SIREN_OFF = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
 })
 
 
+def _sip_capable_cameras(arlo) -> set[str]:
+    """Return the device ids of the cameras that speak SIP/WebRTC.
+
+    Runs in an executor: the first lookup per model hits Arlo's capability
+    endpoint. A camera that can't be classified - no capability document,
+    network hiccup - is simply left off the list and keeps the RTSPS path.
+    """
+    capable = set()
+    for camera in arlo.cameras:
+        try:
+            if camera.supports_sip_streaming:
+                _LOGGER.info(f"{camera.name} supports SIP/WebRTC streaming")
+                capable.add(camera.device_id)
+        except Exception as e:
+            _LOGGER.warning(f"could not read SIP capability for {camera.name}: {e}")
+    return capable
+
+
 async def async_setup_entry(
         hass: HomeAssistant,
         _entry: ConfigEntry,
@@ -192,10 +214,15 @@ async def async_setup_entry(
     arlo = hass.data[COMPONENT_DATA]
     aarlo_config = hass.data[COMPONENT_CONFIG][COMPONENT_DOMAIN]
 
+    sip_capable = await hass.async_add_executor_job(_sip_capable_cameras, arlo)
+
     cameras = []
     cameras_with_siren = False
     for camera in arlo.cameras:
-        cameras.append(ArloCam(camera, aarlo_config, hass))
+        if camera.device_id in sip_capable:
+            cameras.append(ArloSipCam(camera, aarlo_config, hass))
+        else:
+            cameras.append(ArloCam(camera, aarlo_config, hass))
         if camera.has_capability(SIREN_STATE_KEY):
             cameras_with_siren = True
 
@@ -677,6 +704,135 @@ class ArloCam(Camera):
 
     async def async_stop_recording(self):
         return await self.hass.async_add_executor_job(self.stop_recording)
+
+
+class ArloSipCam(ArloCam):
+    """An Arlo camera that streams live video over SIP/WebRTC.
+
+    This is the engine Arlo's own apps - including my.arlo.com in a browser -
+    use for live view: SIP over a WebSocket carries the offer/answer exchange
+    and the media flows peer-to-peer over WebRTC, with no `rtsps://` relay in
+    the middle. pyaarlo handles only the signalling; the browser's own
+    `RTCPeerConnection` is the other end, so Home Assistant never touches a
+    media packet on this path.
+
+    Why a subclass rather than a flag on `ArloCam`: Home Assistant decides
+    whether a camera is a native WebRTC camera by comparing
+    `type(self).async_handle_async_webrtc_offer` against `Camera`'s, once, in
+    `Camera.__init__`. That check is class-level, so defining the override on
+    `ArloCam` would claim WebRTC for *every* Arlo camera - including the ones
+    that only speak RTSPS - and a native WebRTC camera advertises `WEB_RTC`
+    *instead of* `HLS`. The `nest` integration splits its entities for exactly
+    this reason.
+
+    Everything else - snapshots, the library, the siren, recording, and the
+    `aarlo_stream_url` websocket the Lovelace card uses - is inherited
+    unchanged and still goes over RTSPS.
+    """
+
+    def __init__(self, camera, aarlo_config, hass):
+        super().__init__(camera, aarlo_config, hass)
+        self._ice_servers: list[RTCIceServer] = []
+        self._sip_session_id: str | None = None
+
+    async def async_added_to_hass(self):
+        await super().async_added_to_hass()
+        self.hass.async_create_background_task(
+            self._async_refresh_ice_servers(),
+            f"aarlo sip ice servers {self.entity_id}",
+        )
+
+    async def _async_refresh_ice_servers(self) -> None:
+        """Re-read Arlo's published STUN/TURN servers.
+
+        Cheap - one REST call, no signalling socket - so it runs at startup
+        and again after each negotiation, keeping the TURN credentials we
+        hand the browser reasonably fresh.
+        """
+        try:
+            info = await self.hass.async_add_executor_job(self._camera.get_sip_info)
+        except Exception as e:
+            _LOGGER.debug(f"{self._attr_unique_id} could not refresh ICE servers: {e}")
+            return
+        self._ice_servers = [
+            RTCIceServer(
+                urls=server["urls"],
+                username=server.get("username"),
+                credential=server.get("credential"),
+            )
+            for server in info["ice_servers"]
+        ]
+
+    @callback
+    def _async_get_webrtc_client_configuration(self) -> WebRTCClientConfiguration:
+        """Hand the browser Arlo's own STUN/TURN servers.
+
+        Home Assistant appends whatever ICE servers it is configured with on
+        top of these, so a stale or empty list here degrades to those rather
+        than breaking the stream.
+        """
+        config = WebRTCClientConfiguration()
+        config.configuration.ice_servers.extend(self._ice_servers)
+        return config
+
+    def _negotiate_sip_stream(self, offer_sdp: str) -> str:
+        """Trade the browser's offer for Arlo's answer. Blocking; executor only."""
+        self._camera.stop_sip_stream()
+        self._camera.get_sip_info()
+        return self._camera.start_sip_stream(offer_sdp)
+
+    async def async_handle_async_webrtc_offer(
+        self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage
+    ) -> None:
+        """Negotiate a live stream for the browser's offer."""
+        try:
+            answer_sdp = await self.hass.async_add_executor_job(
+                self._negotiate_sip_stream, offer_sdp
+            )
+        except ArloSipError as e:
+            raise HomeAssistantError(
+                f"SIP negotiation failed for {self._attr_name}: {e}"
+            ) from e
+
+        self._sip_session_id = session_id
+        _LOGGER.debug(f"{self._attr_unique_id} SIP session {session_id} established")
+        send_message(WebRTCAnswer(answer_sdp))
+
+        self.hass.async_create_background_task(
+            self._async_refresh_ice_servers(),
+            f"aarlo sip ice servers {self.entity_id}",
+        )
+
+    async def async_on_webrtc_candidate(self, session_id: str, candidate) -> None:
+        """Ignore trickled candidates.
+
+        Arlo's SIP proxy takes one complete offer in an INVITE and answers it
+        once; there is no channel to trickle later candidates into. The offer
+        the frontend sends already carries what it had gathered, and Arlo
+        answers with a public host candidate the browser can reach directly.
+
+        `candidate` is deliberately unannotated: its type moved from
+        `RTCIceCandidate` to `RTCIceCandidateInit` in 2024.12, and importing
+        the newer name at module scope would break the whole camera platform
+        - not just SIP - on the 2024.11 this integration still supports.
+        """
+        return
+
+    @callback
+    def close_webrtc_session(self, session_id: str) -> None:
+        """Hang up the SIP call behind a session the frontend has dropped."""
+        if self._sip_session_id == session_id:
+            self._sip_session_id = None
+            _LOGGER.debug(f"{self._attr_unique_id} closing SIP session {session_id}")
+            self.hass.async_create_task(
+                self.hass.async_add_executor_job(self._camera.stop_sip_stream)
+            )
+        super().close_webrtc_session(session_id)
+
+    async def async_will_remove_from_hass(self):
+        await super().async_will_remove_from_hass()
+        if self._sip_session_id is not None:
+            self.close_webrtc_session(self._sip_session_id)
 
 
 @websocket_api.async_response

--- a/custom_components/aarlo/camera.py
+++ b/custom_components/aarlo/camera.py
@@ -117,6 +117,9 @@ CAMERA_SERVICE_SNAPSHOT = CAMERA_SERVICE_SCHEMA.extend({
     vol.Required(ATTR_FILENAME): cv.template
 })
 
+ICE_GATHER_DEBOUNCE_SECONDS = 0.3
+ICE_GATHER_MAX_WAIT_SECONDS = 2.0
+
 SERVICE_REQUEST_SNAPSHOT = "camera_request_snapshot"
 SERVICE_REQUEST_SNAPSHOT_TO_FILE = "camera_request_snapshot_to_file"
 SERVICE_REQUEST_VIDEO_TO_FILE = "camera_request_video_to_file"
@@ -706,6 +709,36 @@ class ArloCam(Camera):
         return await self.hass.async_add_executor_job(self.stop_recording)
 
 
+def _merge_trickled_candidates(
+    offer_sdp: str, candidates: list[tuple[int, str]]
+) -> str:
+    """Splice trickled ICE candidates into their `m=` sections of an offer.
+
+    `candidates` is `(sdp_m_line_index, candidate_line)` pairs, `candidate_line`
+    already formatted as a bare `a=candidate:...` attribute line. Insertion
+    happens from the last `m=` section backward so earlier insertions can't
+    shift the line numbers of sections still to be processed.
+    """
+    if not candidates:
+        return offer_sdp
+
+    lines = offer_sdp.replace("\r\n", "\n").split("\n")
+    m_line_positions = [i for i, line in enumerate(lines) if line.startswith("m=")]
+
+    by_m_line: dict[int, list[str]] = {}
+    for index, line in candidates:
+        by_m_line.setdefault(index, []).append(line)
+
+    for m_line_index in reversed(range(len(m_line_positions))):
+        extra_lines = by_m_line.get(m_line_index)
+        if not extra_lines:
+            continue
+        insert_at = m_line_positions[m_line_index] + 1
+        lines[insert_at:insert_at] = extra_lines
+
+    return "\r\n".join(line for line in lines if line != "") + "\r\n"
+
+
 class ArloSipCam(ArloCam):
     """An Arlo camera that streams live video over SIP/WebRTC.
 
@@ -734,6 +767,7 @@ class ArloSipCam(ArloCam):
         super().__init__(camera, aarlo_config, hass)
         self._ice_servers: list[RTCIceServer] = []
         self._sip_session_id: str | None = None
+        self._pending_candidates: dict[str, tuple[list[tuple[int, str]], asyncio.Event]] = {}
 
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
@@ -781,13 +815,43 @@ class ArloSipCam(ArloCam):
         self._camera.get_sip_info()
         return self._camera.start_sip_stream(offer_sdp)
 
+    async def _wait_for_ice_gathering(self, session_id: str) -> list[tuple[int, str]]:
+        """Buffers trickled candidates until gathering looks finished.
+
+        There's no explicit "gathering complete" signal from the frontend (see
+        the module-level comment above `ICE_GATHER_DEBOUNCE_SECONDS`), so this
+        resets a short debounce timer on every candidate and treats silence as
+        done, bounded by a hard ceiling.
+        """
+        candidates: list[tuple[int, str]] = []
+        new_candidate = asyncio.Event()
+        self._pending_candidates[session_id] = (candidates, new_candidate)
+        try:
+            deadline = self.hass.loop.time() + ICE_GATHER_MAX_WAIT_SECONDS
+            while True:
+                new_candidate.clear()
+                remaining = deadline - self.hass.loop.time()
+                if remaining <= 0:
+                    break
+                try:
+                    await asyncio.wait_for(
+                        new_candidate.wait(), timeout=min(ICE_GATHER_DEBOUNCE_SECONDS, remaining)
+                    )
+                except asyncio.TimeoutError:
+                    break
+        finally:
+            self._pending_candidates.pop(session_id, None)
+        return candidates
+
     async def async_handle_async_webrtc_offer(
         self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage
     ) -> None:
         """Negotiate a live stream for the browser's offer."""
+        candidates = await self._wait_for_ice_gathering(session_id)
+        full_offer_sdp = _merge_trickled_candidates(offer_sdp, candidates)
         try:
             answer_sdp = await self.hass.async_add_executor_job(
-                self._negotiate_sip_stream, offer_sdp
+                self._negotiate_sip_stream, full_offer_sdp
             )
         except ArloSipError as e:
             raise HomeAssistantError(
@@ -804,19 +868,28 @@ class ArloSipCam(ArloCam):
         )
 
     async def async_on_webrtc_candidate(self, session_id: str, candidate) -> None:
-        """Ignore trickled candidates.
+        """Buffers a trickled candidate for the offer still being assembled.
 
         Arlo's SIP proxy takes one complete offer in an INVITE and answers it
-        once; there is no channel to trickle later candidates into. The offer
-        the frontend sends already carries what it had gathered, and Arlo
-        answers with a public host candidate the browser can reach directly.
+        once - there is no channel to trickle candidates into after the fact.
+        So candidates arriving here are held and spliced into the offer SDP
+        by `_wait_for_ice_gathering` / `_merge_trickled_candidates` before the
+        INVITE ever goes out. Anything that arrives after that buffering
+        window has closed is too late to matter and is dropped.
 
         `candidate` is deliberately unannotated: its type moved from
         `RTCIceCandidate` to `RTCIceCandidateInit` in 2024.12, and importing
         the newer name at module scope would break the whole camera platform
         - not just SIP - on the 2024.11 this integration still supports.
         """
-        return
+        pending = self._pending_candidates.get(session_id)
+        if pending is None:
+            return
+        candidates, new_candidate = pending
+        if candidate.candidate:
+            index = candidate.sdp_m_line_index or 0
+            candidates.append((index, f"a={candidate.candidate}"))
+        new_candidate.set()
 
     @callback
     def close_webrtc_session(self, session_id: str) -> None:


### PR DESCRIPTION
## ⚠️ Depends on a companion pyaarlo PR

This PR only works together with **[pyaarlo #210](https://github.com/twrecked/pyaarlo/pull/210) — "feat: add SIP/WebRTC signaling support for live streaming"**, which adds `ArloCamera.get_sip_info()` / `start_sip_stream()` / `stop_sip_stream()` and the `supports_sip_streaming` capability lookup this integration calls into. It should be merged and released to PyPI first (or reviewed alongside this one) — `manifest.json` here is intentionally left untouched (still pinned to `pyaarlo==0.8.0.22`) so this PR doesn't carry a temporary pointer to a personal fork commit; bumping the `pyaarlo` requirement to the released version that includes SIP support is a follow-up once that PR lands.

## Summary

Newer Arlo cameras support a second, completely separate live-view engine: signaling over SIP-in-a-WebSocket, media over WebRTC — this is what `my.arlo.com` and the official apps actually use. There's no `rtsps://` relay and no `ffmpeg` transcode in this path: video goes straight from the camera to the browser, so it starts faster and costs the Home Assistant server almost nothing.

There is nothing to configure. At startup, the integration asks Arlo which of your cameras declare SIP support and sets those up as native WebRTC camera entities. Every other camera — and every other feature of a SIP-capable camera (snapshots, the library, the siren, recording, the `aarlo-glance` card's own streaming) — is untouched and still goes over RTSPS.

## What's added

- **`custom_components/aarlo/camera.py`**:
  - `_sip_capable_cameras()`: at setup, asks each camera's capability document whether it speaks SIP/WebRTC. A camera that can't be classified (no document, network hiccup) is simply left off the list and keeps the RTSPS path — never blocks setup.
  - **`ArloSipCam(ArloCam)`**: a new entity subclass implementing Home Assistant's native async WebRTC camera protocol (`async_handle_async_webrtc_offer`, `async_on_webrtc_candidate`, `close_webrtc_session`, `_async_get_webrtc_client_configuration`). It's a subclass rather than a flag on `ArloCam` because Home Assistant decides whether a camera is a native WebRTC camera by a class-level check in `Camera.__init__` — putting the override directly on `ArloCam` would have claimed WebRTC for every Arlo camera, including RTSPS-only ones, and a native WebRTC camera advertises `WEB_RTC` *instead of* `HLS` (same pattern the `nest` integration uses).
  - Trickle-ICE handling: Arlo's SIP proxy takes one complete offer in a single INVITE and answers it once — there's no channel to trickle candidates into afterward. `_wait_for_ice_gathering` buffers candidates behind a short debounce (`ICE_GATHER_DEBOUNCE_SECONDS` = 0.3s, capped at `ICE_GATHER_MAX_WAIT_SECONDS` = 2s, since the frontend gives no explicit "gathering complete" signal), and `_merge_trickled_candidates` splices them into the right `m=` section of the offer SDP before the INVITE is sent.
  - ICE servers (STUN/TURN) are fetched from Arlo at startup and refreshed after each negotiation via `_async_refresh_ice_servers`, and handed to the browser through `_async_get_webrtc_client_configuration` — Home Assistant appends its own configured servers on top, so a stale/empty list degrades gracefully rather than breaking the stream.
- **`README-advanced.md`** — new "SIP/WebRTC Streaming" section explaining what it is, that it's zero-config, and the operational caveats (one live viewer at a time; SIP and RTSPS are mutually exclusive on the camera; falls back to Arlo's TURN servers when the browser's network blocks outbound UDP).

## Behavior notes / things worth knowing

- A WebRTC camera advertises `web_rtc` to the frontend *instead of* `hls`. The standard more-info dialog uses WebRTC for those cameras; the `aarlo-glance` card uses its own websocket stream and is unaffected either way.
- The camera serves one live stream at a time — opening it in a second place hangs up the first.
- Arlo's firmware won't run both engines at once. Starting a recording while a WebRTC stream is live surfaces Arlo's own error, *"SIP Streaming in progress, RTSP Streaming is not allowed"*.
- Media is peer-to-peer between the browser and Arlo; Home Assistant never touches a media packet on this path, only the SIP signaling (via pyaarlo).

## Out of scope

- No changes to the RTSPS path, snapshots, recording, siren, or the `aarlo-glance` streaming websocket — all inherited unchanged from `ArloCam`.
- Push-to-talk over SIP is not wired up in this PR (pyaarlo detects `supports_sip_push_to_talk` but nothing here calls it yet).